### PR TITLE
load unity .mdb's when they exist

### DIFF
--- a/MelonLoader.ModHandler/MelonHandler.cs
+++ b/MelonLoader.ModHandler/MelonHandler.cs
@@ -112,7 +112,19 @@ namespace MelonLoader
             Main.LegacySupport(_Mods, _Plugins, MelonLoaderBase._IsVRChat, MelonLoaderBase._IsBoneworks);
         }
 
-        public static void LoadFromFile(string filelocation, bool isPlugin = false) => LoadFromAssembly((Imports.IsDebugMode() ? Assembly.LoadFrom(filelocation) : Assembly.Load(File.ReadAllBytes(filelocation))), isPlugin, filelocation);
+        public static void LoadFromFile(string filelocation, bool isPlugin = false)
+        {
+            var assembly = File.ReadAllBytes(filelocation);
+            byte[] symbols = { 0 };
+
+            if (File.Exists(filelocation + ".mdb"))
+            {
+                symbols = File.ReadAllBytes(filelocation + ".mdb");
+            }
+
+            LoadFromAssembly((Imports.IsDebugMode() ? Assembly.LoadFrom(filelocation) : Assembly.Load(assembly, symbols)), isPlugin, filelocation);
+        }
+
         public static void LoadFromAssembly(Assembly asm, bool isPlugin = false, string filelocation = null)
         {
             if (!asm.Equals(null))


### PR DESCRIPTION
using [pdb2mdb](https://gist.github.com/jbevain/ba23149da8369e4a966f#file-pdb2mdb-exe) (when csproj has `DebugType` set to `full`) will generate a mono .mdb equivalent of the pdb, which in turn makes exceptions display in a more complete manner.

I don't have any bigger example, but below are before and after pictures of a plugin of mine causing exceptions (note in the latter picture it shows the file and line where the exception occurs)

![Honeyview_oCRfXTEY2T](https://user-images.githubusercontent.com/2692729/105611192-16073680-5db4-11eb-8803-4fff9775d0a5.png)

![VRChat_shS8UL0JPH](https://user-images.githubusercontent.com/2692729/105611202-23bcbc00-5db4-11eb-99de-223a6a376845.png)

