### PR TITLE
Continuous Integration Using Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,4 +99,4 @@ jobs:
         name: Uploading x86 Zip...
         with:
           name: MelonLoader.x86.CI
-          path: ./Output/Debug/x64/*
+          path: ./Output/Debug/x86/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,12 +20,58 @@ jobs:
       - uses: actions/checkout@v2
       - name: setup-msbuild
         uses: microsoft/setup-msbuild@v1
-      - name: Build Script
+      - name: Build Melonloader Core
+        shell: cmd
         run: |
-          echo Invoking MSBuild...
           msbuild /t:Rebuild
-          echo Done
+          mkdir Output\Debug\x64
+          mkdir Output\Debug\x64\MelonLoader
+          mkdir Output\Debug\x86
+          mkdir Output\Debug\x86\MelonLoader
+          xcopy Output\Debug\MelonLoader\ Output\Debug\x64\MelonLoader\ /E /H /Y >nul
+          xcopy Output\Debug\MelonLoader\ Output\Debug\x86\MelonLoader\ /E /H /Y >nul
+          rmdir /S /Q Output\Debug\MelonLoader >nul
+      - name: Build Proxy DLLs For Both Architectures
+        shell: cmd
+        run: |
+          msbuild Proxy\Proxy.vcxproj /p:Platform=x86
+          copy Proxy\Output\Debug\x86\Proxy.dll Output\Debug\x86\version.dll
+          msbuild Proxy\Proxy.vcxproj /p:Platform=x64
+          copy Proxy\Output\Debug\x64\Proxy.dll Output\Debug\x64\version.dll
+      - name: Build Bootstrap Lib for Both Architectures
+        shell: cmd
+        run: |
+          msbuild Bootstrap\Bootstrap.vcxproj /p:Platform=x84
+          copy Bootstrap\Output\Debug\x64\MelonLoader\Bootstrap.dll Output\Debug\x64\Melonloader\Dependencies\
+          msbuild Bootstrap\Bootstrap.vcxproj /p:Platform=x64
+          copy Bootstrap\Output\Debug\x86\MelonLoader\Bootstrap.dll Output\Debug\x86\Melonloader\Dependencies\
+      - name: Copy Base Libs
+        shell: cmd
+        run: |
+          echo Copying Managed Libs to Both Folders...
+          mkdir Output\Debug\x86\MelonLoader\Dependencies\Managed\
+          xcopy BaseLibs\Managed\ Output\Debug\x86\MelonLoader\Dependencies\Managed\ /E /H /Y >nul
+          mkdir Output\Debug\x64\MelonLoader\Dependencies\Managed\
+          xcopy BaseLibs\Managed\ Output\Debug\x64\MelonLoader\Dependencies\Managed\ /E /H /Y >nul
+          echo.
+          echo Copying Mono x86...
+          mkdir Output\Debug\x86\MelonLoader\Dependencies\MonoBleedingEdge.x86\
+          xcopy BaseLibs\MonoBleedingEdge.x86\ Output\Debug\x86\MelonLoader\Dependencies\MonoBleedingEdge.x86\ /E /H /Y >nul/
+          echo.
+          echo Copying Mono x64...
+          mkdir Output\Debug\x64\MelonLoader\Dependencies\MonoBleedingEdge.x64\
+          xcopy BaseLibs\MonoBleedingEdge.x64\ Output\Debug\x64\MelonLoader\Dependencies\MonoBleedingEdge.x64\ /E /H /Y >nul
+          echo.
+          echo Copying bHaptics DLLs...
+          copy BaseLibs\bHaptics.x86.dll Output\Debug\x86\MelonLoader\Dependencies\ >nul
+          copy BaseLibs\bHaptics.x64.dll Output\Debug\x64\MelonLoader\Dependencies\ >nul
       - uses: actions/upload-artifact@v2
+        name: Uploading x64 Zip...
         with:
-          name: Windows Debug Build
-          path: ./Output/Debug/MelonLoader/*
+          name: Windows x64
+          path: ./Output/Debug/x64/*
+      - uses: actions/upload-artifact@v2
+        name: Uploading x86 Zip...
+        with:
+          name: Windows x86
+          path: ./Output/Debug/x64/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,9 +50,9 @@ jobs:
         shell: cmd
         run: |
           msbuild Bootstrap\Bootstrap.vcxproj /p:Platform=x86
-          copy Bootstrap\Output\Debug\x64\MelonLoader\Bootstrap.dll Output\Debug\x64\Melonloader\Dependencies\
+          copy Bootstrap\Output\Debug\x86\MelonLoader\Dependencies\Bootstrap.dll Output\Debug\x86\Melonloader\Dependencies\
           msbuild Bootstrap\Bootstrap.vcxproj /p:Platform=x64
-          copy Bootstrap\Output\Debug\x86\MelonLoader\Bootstrap.dll Output\Debug\x86\Melonloader\Dependencies\
+          copy Bootstrap\Output\Debug\x64\MelonLoader\Dependencies\Bootstrap.dll Output\Debug\x64\Melonloader\Dependencies\
       - name: Copy Base Libs
         shell: cmd
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,9 +43,9 @@ jobs:
         shell: cmd
         run: |
           msbuild Proxy\Proxy.vcxproj /p:Platform=x86
-          copy Proxy\Output\Debug\x86\Proxy.dll Output\Debug\x86\version.dll
+          copy Proxy\Output\Debug\x86\version.dll Output\Debug\x86\version.dll
           msbuild Proxy\Proxy.vcxproj /p:Platform=x64
-          copy Proxy\Output\Debug\x64\Proxy.dll Output\Debug\x64\version.dll
+          copy Proxy\Output\Debug\x64\version.dll Output\Debug\x64\version.dll
       - name: Build Bootstrap Lib for Both Architectures
         shell: cmd
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: Build MelonLoader
+
+# Controls when the action will run. 
+on:
+  push:
+    branches: [ci-test]
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: windows-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      - name: Build Script
+        shell: bash
+        run: |
+          echo Invoking MSBuild...
+          msbuild /t:Rebuild
+          echo Done
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Windows Debug Build
+          path: ./Output/Debug/MelonLoader/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,8 @@ jobs:
       - name: Build Melonloader Core
         shell: cmd
         run: |
+          mkdir Output
+          mkdir Output\Debug
           mkdir Output\Debug\x64
           mkdir Output\Debug\x64\MelonLoader
           mkdir Output\Debug\x86

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
           copy Bootstrap\Output\Debug\x86\MelonLoader\Dependencies\Bootstrap.dll Output\Debug\x86\Melonloader\Dependencies\
           msbuild Bootstrap\Bootstrap.vcxproj /p:Platform=x64
           copy Bootstrap\Output\Debug\x64\MelonLoader\Dependencies\Bootstrap.dll Output\Debug\x64\Melonloader\Dependencies\
-      - name: Copy Base Libs and Build 
+      - name: Copy Base Libs and Build Final Zip Structure
         shell: cmd
         run: |
           echo Copying Managed Libs to Both Folders...

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,14 +53,14 @@ jobs:
           copy Bootstrap\Output\Debug\x86\MelonLoader\Dependencies\Bootstrap.dll Output\Debug\x86\Melonloader\Dependencies\
           msbuild Bootstrap\Bootstrap.vcxproj /p:Platform=x64
           copy Bootstrap\Output\Debug\x64\MelonLoader\Dependencies\Bootstrap.dll Output\Debug\x64\Melonloader\Dependencies\
-      - name: Copy Base Libs
+      - name: Copy Base Libs and Build 
         shell: cmd
         run: |
           echo Copying Managed Libs to Both Folders...
-          mkdir Output\Debug\x86\MelonLoader\Dependencies\Managed\
-          xcopy BaseLibs\Managed Output\Debug\x86\MelonLoader\Dependencies\Managed\ /E /H /Y
-          mkdir Output\Debug\x64\MelonLoader\Dependencies\Managed\
-          xcopy BaseLibs\Managed Output\Debug\x64\MelonLoader\Dependencies\Managed\ /E /H /Y
+          mkdir Output\Debug\x86\MelonLoader\Managed\
+          xcopy BaseLibs\Managed Output\Debug\x86\MelonLoader\Managed\ /E /H /Y
+          mkdir Output\Debug\x64\MelonLoader\Managed\
+          xcopy BaseLibs\Managed Output\Debug\x64\MelonLoader\Managed\ /E /H /Y
           echo.
           echo Copying Mono x86...
           mkdir Output\Debug\x86\MelonLoader\Dependencies\MonoBleedingEdge.x86\
@@ -73,13 +73,30 @@ jobs:
           echo Copying bHaptics DLLs...
           copy BaseLibs\bHaptics.x86.dll Output\Debug\x86\MelonLoader\Dependencies\
           copy BaseLibs\bHaptics.x64.dll Output\Debug\x64\MelonLoader\Dependencies\
+          echo.
+          echo Copying NOTICE.txt...
+          copy NOTICE.txt Output\Debug\x86
+          copy NOTICE.txt Output\Debug\x64
+          echo.
+          echo Creating Documentation Folder...
+          mkdir Documentation
+          copy CHANGELOG.md Documentation\
+          copy LICENSE.md Documentation\
+          copy NOTICE.txt Documentation\
+          copy README.md Documentation
+          mkdir Output\Debug\x64\MelonLoader\Documentation
+          mkdir Output\Debug\x86\MelonLoader\Documentation
+          echo.
+          echo Copying Documentation to Final Artifact Folders...
+          xcopy Documentation Output\Debug\x64\MelonLoader\Documentation\ /E /H /Y
+          xcopy Documentation Output\Debug\x86\MelonLoader\Documentation\ /E /H /Y
       - uses: actions/upload-artifact@v2
         name: Uploading x64 Zip...
         with:
-          name: Windows x64
+          name: MelonLoader.x64.CI
           path: ./Output/Debug/x64/*
       - uses: actions/upload-artifact@v2
         name: Uploading x86 Zip...
         with:
-          name: Windows x86
+          name: MelonLoader.x86.CI
           path: ./Output/Debug/x64/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,13 +23,19 @@ jobs:
       - name: Build Melonloader Core
         shell: cmd
         run: |
-          msbuild /t:Rebuild
           mkdir Output\Debug\x64
           mkdir Output\Debug\x64\MelonLoader
           mkdir Output\Debug\x86
           mkdir Output\Debug\x86\MelonLoader
-          xcopy Output\Debug\MelonLoader\ Output\Debug\x64\MelonLoader\ /E /H /Y >nul
-          xcopy Output\Debug\MelonLoader\ Output\Debug\x86\MelonLoader\ /E /H /Y >nul
+          echo Building x64...
+          msbuild /t:Rebuild /p:Platform=x64
+          echo Copying x64...
+          xcopy Output\Debug\MelonLoader\ Output\Debug\x64\MelonLoader\ /E /H /Y
+          rmdir /S /Q Output\Debug\MelonLoader >nul
+          echo Building x86...
+          msbuild /t:Rebuild /p:Platform=x86
+          echo Copying x86...
+          xcopy Output\Debug\MelonLoader\ Output\Debug\x86\MelonLoader\ /E /H /Y
           rmdir /S /Q Output\Debug\MelonLoader >nul
       - name: Build Proxy DLLs For Both Architectures
         shell: cmd
@@ -50,21 +56,21 @@ jobs:
         run: |
           echo Copying Managed Libs to Both Folders...
           mkdir Output\Debug\x86\MelonLoader\Dependencies\Managed\
-          xcopy BaseLibs\Managed\ Output\Debug\x86\MelonLoader\Dependencies\Managed\ /E /H /Y >nul
+          xcopy BaseLibs\Managed\ Output\Debug\x86\MelonLoader\Dependencies\Managed\ /E /H /Y
           mkdir Output\Debug\x64\MelonLoader\Dependencies\Managed\
-          xcopy BaseLibs\Managed\ Output\Debug\x64\MelonLoader\Dependencies\Managed\ /E /H /Y >nul
+          xcopy BaseLibs\Managed\ Output\Debug\x64\MelonLoader\Dependencies\Managed\ /E /H /Y
           echo.
           echo Copying Mono x86...
           mkdir Output\Debug\x86\MelonLoader\Dependencies\MonoBleedingEdge.x86\
-          xcopy BaseLibs\MonoBleedingEdge.x86\ Output\Debug\x86\MelonLoader\Dependencies\MonoBleedingEdge.x86\ /E /H /Y >nul/
+          xcopy BaseLibs\MonoBleedingEdge.x86\ Output\Debug\x86\MelonLoader\Dependencies\MonoBleedingEdge.x86\ /E /H /Y
           echo.
           echo Copying Mono x64...
           mkdir Output\Debug\x64\MelonLoader\Dependencies\MonoBleedingEdge.x64\
-          xcopy BaseLibs\MonoBleedingEdge.x64\ Output\Debug\x64\MelonLoader\Dependencies\MonoBleedingEdge.x64\ /E /H /Y >nul
+          xcopy BaseLibs\MonoBleedingEdge.x64\ Output\Debug\x64\MelonLoader\Dependencies\MonoBleedingEdge.x64\ /E /H /Y
           echo.
           echo Copying bHaptics DLLs...
-          copy BaseLibs\bHaptics.x86.dll Output\Debug\x86\MelonLoader\Dependencies\ >nul
-          copy BaseLibs\bHaptics.x64.dll Output\Debug\x64\MelonLoader\Dependencies\ >nul
+          copy BaseLibs\bHaptics.x86.dll Output\Debug\x86\MelonLoader\Dependencies\
+          copy BaseLibs\bHaptics.x64.dll Output\Debug\x64\MelonLoader\Dependencies\
       - uses: actions/upload-artifact@v2
         name: Uploading x64 Zip...
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Build Bootstrap Lib for Both Architectures
         shell: cmd
         run: |
-          msbuild Bootstrap\Bootstrap.vcxproj /p:Platform=x84
+          msbuild Bootstrap\Bootstrap.vcxproj /p:Platform=x86
           copy Bootstrap\Output\Debug\x64\MelonLoader\Bootstrap.dll Output\Debug\x64\Melonloader\Dependencies\
           msbuild Bootstrap\Bootstrap.vcxproj /p:Platform=x64
           copy Bootstrap\Output\Debug\x86\MelonLoader\Bootstrap.dll Output\Debug\x86\Melonloader\Dependencies\

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build MelonLoader
 # Controls when the action will run. 
 on:
   push:
-    branches: [ci-test]
+    branches: [ci-test, alpha-development]
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,8 +18,9 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
+      - name: setup-msbuild
+        uses: microsoft/setup-msbuild@v1
       - name: Build Script
-        shell: bash
         run: |
           echo Invoking MSBuild...
           msbuild /t:Rebuild

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,12 +32,12 @@ jobs:
           echo Building x64...
           msbuild /t:Rebuild /p:Platform=x64
           echo Copying x64...
-          xcopy Output\Debug\MelonLoader\ Output\Debug\x64\MelonLoader\ /E /H /Y
+          xcopy Output\Debug\MelonLoader Output\Debug\x64\MelonLoader\ /E /H /Y
           rmdir /S /Q Output\Debug\MelonLoader >nul
           echo Building x86...
           msbuild /t:Rebuild /p:Platform=x86
           echo Copying x86...
-          xcopy Output\Debug\MelonLoader\ Output\Debug\x86\MelonLoader\ /E /H /Y
+          xcopy Output\Debug\MelonLoader Output\Debug\x86\MelonLoader\ /E /H /Y
           rmdir /S /Q Output\Debug\MelonLoader >nul
       - name: Build Proxy DLLs For Both Architectures
         shell: cmd
@@ -58,17 +58,17 @@ jobs:
         run: |
           echo Copying Managed Libs to Both Folders...
           mkdir Output\Debug\x86\MelonLoader\Dependencies\Managed\
-          xcopy BaseLibs\Managed\ Output\Debug\x86\MelonLoader\Dependencies\Managed\ /E /H /Y
+          xcopy BaseLibs\Managed Output\Debug\x86\MelonLoader\Dependencies\Managed\ /E /H /Y
           mkdir Output\Debug\x64\MelonLoader\Dependencies\Managed\
-          xcopy BaseLibs\Managed\ Output\Debug\x64\MelonLoader\Dependencies\Managed\ /E /H /Y
+          xcopy BaseLibs\Managed Output\Debug\x64\MelonLoader\Dependencies\Managed\ /E /H /Y
           echo.
           echo Copying Mono x86...
           mkdir Output\Debug\x86\MelonLoader\Dependencies\MonoBleedingEdge.x86\
-          xcopy BaseLibs\MonoBleedingEdge.x86\ Output\Debug\x86\MelonLoader\Dependencies\MonoBleedingEdge.x86\ /E /H /Y
+          xcopy BaseLibs\MonoBleedingEdge.x86 Output\Debug\x86\MelonLoader\Dependencies\MonoBleedingEdge.x86\ /E /H /Y
           echo.
           echo Copying Mono x64...
           mkdir Output\Debug\x64\MelonLoader\Dependencies\MonoBleedingEdge.x64\
-          xcopy BaseLibs\MonoBleedingEdge.x64\ Output\Debug\x64\MelonLoader\Dependencies\MonoBleedingEdge.x64\ /E /H /Y
+          xcopy BaseLibs\MonoBleedingEdge.x64 Output\Debug\x64\MelonLoader\Dependencies\MonoBleedingEdge.x64\ /E /H /Y
           echo.
           echo Copying bHaptics DLLs...
           copy BaseLibs\bHaptics.x86.dll Output\Debug\x86\MelonLoader\Dependencies\

--- a/Bootstrap/Utils/CommandLine.cpp
+++ b/Bootstrap/Utils/CommandLine.cpp
@@ -190,14 +190,14 @@ void CommandLine::ReadIniFile()
 	}
 	else
 	{
-		std::string version = iniFile->ReadValue("AssemblyGenerator", "ForceIl2CppDumper_Version");
+		std::string version = iniFile->ReadValue("AssemblyGenerator", "ForceCpp2IL_Version");
 		if (!version.empty())
 		{
-			AssemblyGenerator::ForceVersion_Il2CppDumper = new char[version.size() + 1];
-			std::copy(version.begin(), version.end(), AssemblyGenerator::ForceVersion_Il2CppDumper);
-			AssemblyGenerator::ForceVersion_Il2CppDumper[version.size()] = '\0';
+			AssemblyGenerator::ForceVersion_Cpp2IL = new char[version.size() + 1];
+			std::copy(version.begin(), version.end(), AssemblyGenerator::ForceVersion_Cpp2IL);
+			AssemblyGenerator::ForceVersion_Cpp2IL[version.size()] = '\0';
 		}
-		iniFile->WriteValue("AssemblyGenerator", "ForceIl2CppDumper_Version", (std::string(AssemblyGenerator::ForceVersion_Il2CppDumper).empty() ? "0.0.0.0" : AssemblyGenerator::ForceVersion_Il2CppDumper));
+		iniFile->WriteValue("AssemblyGenerator", "ForceCpp2IL_Version", (std::string(AssemblyGenerator::ForceVersion_Cpp2IL).empty() ? "0.0.0.0" : AssemblyGenerator::ForceVersion_Cpp2IL));
 	}
 	if (iniFile->ReadValue("AssemblyGenerator", "ForceIl2CppAssemblyUnhollower").empty() || !iniFile->ReadValue("AssemblyGenerator", "ForceIl2CppAssemblyUnhollower")._Equal("true"))
 	{


### PR DESCRIPTION
This PR adds a Github Actions CI file which generates a full MelonLoader zip (debug, not release) on every commit to the alpha-development branch (can be changed to include master once said branch is merged, of course).

Probably want to squash-and-merge this, it took me a while to get right so it's ~~12~~14 commits.

Oh, and it also fixes a compile error in the command line handler file because... to test if the ci worked I had to have it actually compile.