### PR TITLE
Tweaked Assembly Load exceptions logging

### DIFF
--- a/MelonLoader/Melons/Handler.cs
+++ b/MelonLoader/Melons/Handler.cs
@@ -208,12 +208,12 @@ namespace MelonLoader
                 Assembly asm = Assembly.LoadFrom(filepath);
                 if (asm == null)
                 {
-                    MelonLogger.Error("Failed to Load Assembly for " + filepath + "!"); ;
+                    MelonLogger.Error("Failed to Load Assembly for " + filepath + ": Assembly.LoadFrom returned null"); ;
                     return;
                 }
                 LoadFromAssembly(asm, filepath);
             }
-            catch (Exception ex) { MelonLogger.Error(ex.ToString()); }
+            catch (Exception ex) { MelonLogger.Error("Failed to Load Assembly for " + filepath + ": " + ex.ToString()); }
         }
 
         public static void LoadFromByteArray(byte[] filedata, string filelocation = null)
@@ -229,14 +229,20 @@ namespace MelonLoader
                 if (asm == null)
                 {
                     if (string.IsNullOrEmpty(filelocation))
-                        MelonLogger.Error("Failed to Load Assembly!");
+                        MelonLogger.Error("Failed to Load Assembly: Assembly.LoadFrom returned null");
                     else
-                        MelonLogger.Error("Failed to Load Assembly for " + filelocation + "!");
+                        MelonLogger.Error("Failed to Load Assembly for " + filelocation + ": Assembly.LoadFrom returned null");
                     return;
                 }
                 LoadFromAssembly(asm, filelocation);
             }
-            catch (Exception ex) { MelonLogger.Error(ex.ToString()); }
+            catch (Exception ex)
+            {
+                if (string.IsNullOrEmpty(filelocation))
+                    MelonLogger.Error("Failed to Load Assembly:" + ex.ToString());
+                else
+                    MelonLogger.Error("Failed to Load Assembly for " + filelocation + ": " + ex.ToString());
+            }
         }
 
         public static void LoadFromAssembly(Assembly asm, string filelocation = null)

--- a/MelonLoader/Melons/Handler.cs
+++ b/MelonLoader/Melons/Handler.cs
@@ -229,9 +229,9 @@ namespace MelonLoader
                 if (asm == null)
                 {
                     if (string.IsNullOrEmpty(filelocation))
-                        MelonLogger.Error("Failed to Load Assembly: Assembly.LoadFrom returned null");
+                        MelonLogger.Error("Failed to Load Assembly: Assembly.Load returned null");
                     else
-                        MelonLogger.Error("Failed to Load Assembly for " + filelocation + ": Assembly.LoadFrom returned null");
+                        MelonLogger.Error("Failed to Load Assembly for " + filelocation + ": Assembly.Load returned null");
                     return;
                 }
                 LoadFromAssembly(asm, filelocation);


### PR DESCRIPTION
- Replaced `Failed to Load Assembly!` by `Failed to Load Assembly: Assembly.LoadFrom returned null` (LoadFromFile) and `Failed to Load Assembly: Assembly.Load returned null` (LoadFromByteArray)
- Tell `Failed to Load Assembly` when Assembly.Load / Assembly.LoadFile throws an exception
- Include the filelocation in the logs when possible