### PR TITLE
Fix crash when the game path contains unicode charactors

### DIFF
--- a/Bootstrap/Bootstrap.vcxproj
+++ b/Bootstrap/Bootstrap.vcxproj
@@ -168,6 +168,7 @@
     <ClCompile Include="Utils\CommandLine.cpp" />
     <ClCompile Include="Utils\Console.cpp" />
     <ClCompile Include="Utils\Debug.cpp" />
+    <ClCompile Include="Utils\Encoding.cpp" />
     <ClCompile Include="Utils\HashCode.cpp" />
     <ClCompile Include="Utils\IniFile.cpp" />
     <ClCompile Include="Utils\Logger.cpp" />
@@ -191,6 +192,7 @@
     <ClInclude Include="Utils\CommandLine.h" />
     <ClInclude Include="Utils\Console.h" />
     <ClInclude Include="Utils\Debug.h" />
+    <ClInclude Include="Utils\Encoding.h" />
     <ClInclude Include="Utils\HashCode.h" />
     <ClInclude Include="Utils\IniFile.h" />
     <ClInclude Include="Utils\Logger.h" />

--- a/Bootstrap/Bootstrap.vcxproj.filters
+++ b/Bootstrap/Bootstrap.vcxproj.filters
@@ -56,6 +56,9 @@
     <ClCompile Include="Base\DllMain.cpp">
       <Filter>Base</Filter>
     </ClCompile>
+    <ClCompile Include="Utils\Encoding.cpp">
+      <Filter>Utils</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Utils">
@@ -132,6 +135,9 @@
     <ClInclude Include="Core.h" />
     <ClInclude Include="Base\resource.h">
       <Filter>Base</Filter>
+    </ClInclude>
+    <ClInclude Include="Utils\Encoding.h">
+      <Filter>Utils</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Bootstrap/Managers/BaseAssembly.cpp
+++ b/Bootstrap/Managers/BaseAssembly.cpp
@@ -6,7 +6,7 @@
 #include "../Utils/Assertion.h"
 #include "../Utils/Logger.h"
 
-char* BaseAssembly::Path = NULL;
+char* BaseAssembly::PathMono = NULL;
 char* BaseAssembly::PreloadPath = NULL;
 Mono::Method* BaseAssembly::Mono_Start = NULL;
 
@@ -14,7 +14,7 @@ bool BaseAssembly::Initialize()
 {
 	Preload();
 	Debug::Msg("Initializing Base Assembly...");
-	Mono::Assembly* assembly = Mono::Exports::mono_domain_assembly_open(Mono::domain, Path);
+	Mono::Assembly* assembly = Mono::Exports::mono_domain_assembly_open(Mono::domain, PathMono);
 	if (assembly == NULL)
 	{
 		Assertion::ThrowInternalFailure("Failed to Open Mono Assembly!");

--- a/Bootstrap/Managers/BaseAssembly.h
+++ b/Bootstrap/Managers/BaseAssembly.h
@@ -4,7 +4,7 @@
 class BaseAssembly
 {
 public:
-	static char* Path;
+	static char* PathMono;
 	static char* PreloadPath;
 	static bool Initialize();
 	static void Preload();

--- a/Bootstrap/Managers/Game.cpp
+++ b/Bootstrap/Managers/Game.cpp
@@ -7,11 +7,15 @@
 #include "Il2Cpp.h"
 #include "../Utils/Assertion.h"
 #include "../Utils/Logger.h"
+#include "../Utils/Encoding.h"
 #pragma comment(lib,"version.lib")
 
 char* Game::ApplicationPath = NULL;
 char* Game::BasePath = NULL;
 char* Game::DataPath = NULL;
+char* Game::ApplicationPathMono = NULL;
+char* Game::BasePathMono = NULL;
+char* Game::DataPathMono = NULL;
 char* Game::Developer = NULL;
 char* Game::Name = NULL;
 char* Game::UnityVersion = NULL;
@@ -33,6 +37,8 @@ bool Game::Initialize()
 		Il2Cpp::GameAssemblyPath = new char[GameAssemblyPath.size() + 1];
 		std::copy(GameAssemblyPath.begin(), GameAssemblyPath.end(), Il2Cpp::GameAssemblyPath);
 		Il2Cpp::GameAssemblyPath[GameAssemblyPath.size()] = '\0';
+
+		Il2Cpp::GameAssemblyPathMono = Encoding::OsToUtf8(Il2Cpp::GameAssemblyPath);
 	}
 	Il2Cpp::UnityPlayerPath = new char[UnityPlayerPath.size() + 1];
 	std::copy(UnityPlayerPath.begin(), UnityPlayerPath.end(), Il2Cpp::UnityPlayerPath);
@@ -61,6 +67,12 @@ bool Game::SetupPaths()
 	DataPath = new char[DataPathStr.size() + 1];
 	std::copy(DataPathStr.begin(), DataPathStr.end(), DataPath);
 	DataPath[DataPathStr.size()] = '\0';
+
+#define MONO_STR(s) ((s ## Mono) = Encoding::OsToUtf8((s)))
+	MONO_STR(ApplicationPath);
+	MONO_STR(BasePath);
+	MONO_STR(DataPath);
+#undef MONO_STR
 
 	return true;
 }

--- a/Bootstrap/Managers/Game.h
+++ b/Bootstrap/Managers/Game.h
@@ -7,6 +7,9 @@ public:
 	static char* ApplicationPath;
 	static char* BasePath;
 	static char* DataPath;
+	static char* ApplicationPathMono;
+	static char* BasePathMono;
+	static char* DataPathMono;
 	static char* Developer;
 	static char* Name;
 	static char* UnityVersion;

--- a/Bootstrap/Managers/Il2Cpp.cpp
+++ b/Bootstrap/Managers/Il2Cpp.cpp
@@ -14,6 +14,7 @@
 
 Il2Cpp::Domain* Il2Cpp::domain = NULL;
 char* Il2Cpp::GameAssemblyPath = NULL;
+char* Il2Cpp::GameAssemblyPathMono = NULL;
 char* Il2Cpp::UnityPlayerPath = NULL;
 HMODULE Il2Cpp::Module = NULL;
 void* Il2Cpp::UnityTLSInterfaceStruct = NULL;

--- a/Bootstrap/Managers/Il2Cpp.h
+++ b/Bootstrap/Managers/Il2Cpp.h
@@ -10,6 +10,7 @@ public:
 	struct Object;
 
 	static char* GameAssemblyPath;
+	static char* GameAssemblyPathMono;
 	static char* UnityPlayerPath;
 	static HMODULE Module;
 	static Domain* domain;

--- a/Bootstrap/Managers/InternalCalls.cpp
+++ b/Bootstrap/Managers/InternalCalls.cpp
@@ -96,13 +96,13 @@ bool InternalCalls::MelonUtils::IsGame32Bit()
 }
 bool InternalCalls::MelonUtils::IsGameIl2Cpp() { return Game::IsIl2Cpp; }
 bool InternalCalls::MelonUtils::IsOldMono() { return Mono::IsOldMono; }
-Mono::String* InternalCalls::MelonUtils::GetApplicationPath() { return Mono::Exports::mono_string_new(Mono::domain, Game::ApplicationPath); }
+Mono::String* InternalCalls::MelonUtils::GetApplicationPath() { return Mono::Exports::mono_string_new(Mono::domain, Game::ApplicationPathMono); }
 Mono::String* InternalCalls::MelonUtils::GetGameName() { return Mono::Exports::mono_string_new(Mono::domain, Game::Name); }
 Mono::String* InternalCalls::MelonUtils::GetGameDeveloper() { return Mono::Exports::mono_string_new(Mono::domain, Game::Developer); }
-Mono::String* InternalCalls::MelonUtils::GetGameDirectory() { return Mono::Exports::mono_string_new(Mono::domain, Game::BasePath); }
-Mono::String* InternalCalls::MelonUtils::GetGameDataDirectory() { return Mono::Exports::mono_string_new(Mono::domain, Game::DataPath); }
+Mono::String* InternalCalls::MelonUtils::GetGameDirectory() { return Mono::Exports::mono_string_new(Mono::domain, Game::BasePathMono); }
+Mono::String* InternalCalls::MelonUtils::GetGameDataDirectory() { return Mono::Exports::mono_string_new(Mono::domain, Game::DataPathMono); }
 Mono::String* InternalCalls::MelonUtils::GetUnityVersion() { return Mono::Exports::mono_string_new(Mono::domain, Game::UnityVersion); }
-Mono::String* InternalCalls::MelonUtils::GetManagedDirectory() { return Mono::Exports::mono_string_new(Mono::domain, Mono::ManagedPath); }
+Mono::String* InternalCalls::MelonUtils::GetManagedDirectory() { return Mono::Exports::mono_string_new(Mono::domain, Mono::ManagedPathMono); }
 Mono::String* InternalCalls::MelonUtils::GetHashCode() { return Mono::Exports::mono_string_new(Mono::domain, HashCode::Hash.c_str()); }
 void InternalCalls::MelonUtils::SCT(Mono::String* title)
 {
@@ -222,9 +222,9 @@ void InternalCalls::AssemblyGenerator_Logger::AddInternalCalls()
 #pragma endregion
 
 #pragma region AssemblyGenerator_Utils
-Mono::String* InternalCalls::AssemblyGenerator_Utils::GetGameAssemblyPath() { return Mono::Exports::mono_string_new(Mono::domain, Il2Cpp::GameAssemblyPath); }
-Mono::String* InternalCalls::AssemblyGenerator_Utils::GetConfigDirectory() { return Mono::Exports::mono_string_new(Mono::domain, Mono::ConfigPath); }
-Mono::String* InternalCalls::AssemblyGenerator_Utils::GetAssemblyGeneratorPath() { return Mono::Exports::mono_string_new(Mono::domain, AssemblyGenerator::Path); }
+Mono::String* InternalCalls::AssemblyGenerator_Utils::GetGameAssemblyPath() { return Mono::Exports::mono_string_new(Mono::domain, Il2Cpp::GameAssemblyPathMono); }
+Mono::String* InternalCalls::AssemblyGenerator_Utils::GetConfigDirectory() { return Mono::Exports::mono_string_new(Mono::domain, Mono::ConfigPathMono); }
+Mono::String* InternalCalls::AssemblyGenerator_Utils::GetAssemblyGeneratorPath() { return Mono::Exports::mono_string_new(Mono::domain, AssemblyGenerator::PathMono); }
 bool InternalCalls::AssemblyGenerator_Utils::ForceRegeneration() { return AssemblyGenerator::ForceRegeneration; }
 Mono::String* InternalCalls::AssemblyGenerator_Utils::ForceVersion_UnityDependencies() { return ((AssemblyGenerator::ForceVersion_UnityDependencies != NULL) ? Mono::Exports::mono_string_new(Mono::domain, AssemblyGenerator::ForceVersion_UnityDependencies) : NULL); }
 Mono::String* InternalCalls::AssemblyGenerator_Utils::ForceVersion_Dumper() { return ((AssemblyGenerator::ForceVersion_Dumper != NULL) ? Mono::Exports::mono_string_new(Mono::domain, AssemblyGenerator::ForceVersion_Dumper) : NULL); }

--- a/Bootstrap/Managers/Mono.cpp
+++ b/Bootstrap/Managers/Mono.cpp
@@ -5,6 +5,7 @@
 #include "..\Utils\Assertion.h"
 #include "..\Utils\CommandLine.h"
 #include "..\Utils\Debug.h"
+#include "..\Utils\Encoding.h"
 #include "..\Core.h"
 #include "InternalCalls.h"
 #include "BaseAssembly.h"
@@ -15,8 +16,10 @@ const char* Mono::LibNames[] = { "mono", "mono-2.0-bdwgc", "mono-2.0-sgen", "mon
 const char* Mono::FolderNames[] = { "Mono", "MonoBleedingEdge", "MonoBleedingEdge.x86", "MonoBleedingEdge.x64" };
 char* Mono::BasePath = NULL;
 char* Mono::ManagedPath = NULL;
+char* Mono::ManagedPathMono = NULL;
 char* Mono::ConfigPath = NULL;
-char* Mono::MonoConfigPath = NULL;
+char* Mono::ConfigPathMono = NULL;
+char* Mono::MonoConfigPathMono = NULL;
 HMODULE Mono::Module = NULL;
 HMODULE Mono::PosixHelper = NULL;
 Mono::Domain* Mono::domain = NULL;
@@ -143,6 +146,7 @@ bool Mono::SetupPaths()
 		Assertion::ThrowInternalFailure("Failed to Find Mono Directory!");
 		return false;
 	}
+#define MONO_STR(s) ((s ## Mono) = Encoding::OsToUtf8((s)))
 
 	if (Game::IsIl2Cpp)
 	{
@@ -161,9 +165,14 @@ bool Mono::SetupPaths()
 		ConfigPath[ConfigPathStr.size()] = '\0';
 
 		std::string MonoConfigPathStr = (MonoDir + "\\etc");
-		MonoConfigPath = new char[MonoConfigPathStr.size() + 1];
-		std::copy(MonoConfigPathStr.begin(), MonoConfigPathStr.end(), MonoConfigPath);
-		MonoConfigPath[MonoConfigPathStr.size()] = '\0';
+		MonoConfigPathMono = new char[MonoConfigPathStr.size() + 1];
+		std::copy(MonoConfigPathStr.begin(), MonoConfigPathStr.end(), MonoConfigPathMono);
+		MonoConfigPathMono[MonoConfigPathStr.size()] = '\0';
+
+		MonoConfigPathMono = Encoding::OsToUtf8(MonoConfigPathMono);
+
+		MONO_STR(ManagedPath);
+		MONO_STR(ConfigPath);
 
 		return true;
 	}
@@ -185,8 +194,12 @@ bool Mono::SetupPaths()
 	std::copy(ConfigPathStr.begin(), ConfigPathStr.end(), ConfigPath);
 	ConfigPath[ConfigPathStr.size()] = '\0';
 
-	MonoConfigPath = ConfigPath;
+	MonoConfigPathMono = Encoding::OsToUtf8(ConfigPath);
 
+	MONO_STR(ManagedPath);
+	MONO_STR(ConfigPath);
+
+#undef MONO_STR
 	return true;
 }
 
@@ -195,15 +208,25 @@ void Mono::CreateDomain(const char* name)
 	if (domain != NULL)
 		return;
 	Debug::Msg("Creating Mono Domain...");
-	Exports::mono_set_assemblies_path(ManagedPath);
-	Exports::mono_assembly_setrootdir(ManagedPath);
-	Exports::mono_set_config_dir(MonoConfigPath);
-	if (!IsOldMono)
+	Exports::mono_set_assemblies_path(ManagedPathMono);
+	Exports::mono_assembly_setrootdir(ManagedPathMono);
+	Exports::mono_set_config_dir(MonoConfigPathMono);
+	if (!IsOldMono) {
+		// FIXME: Here is a temporary way to handle command line. Should be done in `CommandLine::Read`.
+		if (CommandLine::argc == 1) {
+			// FIXME: memory leaking
+			// The first one usually is the path of exe which contains non-ASCII charactors, so we only convert it.
+			CommandLine::argv[0] = Encoding::OsToUtf8(CommandLine::argv[0]);
+		}
 		Exports::mono_runtime_set_main_args(CommandLine::argc, CommandLine::argv);
+	}
 	domain = Exports::mono_jit_init(name);
 	Exports::mono_thread_set_main(Exports::mono_thread_current());
 	if (!IsOldMono)
-		Exports::mono_domain_set_config(domain, Game::BasePath, name);
+	{
+		Debug::Msg("Setting Mono Domain Config...");
+		Exports::mono_domain_set_config(domain, Game::BasePathMono, name);
+	}
 }
 
 void Mono::AddInternalCall(const char* name, void* method)
@@ -253,7 +276,7 @@ bool Mono::Exports::Initialize()
 	else
 		MONODEF(g_free)
 
-	if (Game::IsIl2Cpp) 
+	if (Game::IsIl2Cpp)
 	{
 		MONODEF(mono_set_assemblies_path)
 		MONODEF(mono_assembly_setrootdir)
@@ -313,7 +336,7 @@ Mono::Domain* Mono::Hooks::mono_jit_init_version(const char* name, const char* v
 	domain = Exports::mono_jit_init_version(name, version);
 	Exports::mono_thread_set_main(Exports::mono_thread_current());
 	if (!IsOldMono)
-		Exports::mono_domain_set_config(domain, Game::BasePath, name);
+		Exports::mono_domain_set_config(domain, Game::BasePathMono, name);
 	InternalCalls::Initialize();
 	if (BaseAssembly::Initialize())
 	{

--- a/Bootstrap/Managers/Mono.cpp
+++ b/Bootstrap/Managers/Mono.cpp
@@ -212,13 +212,7 @@ void Mono::CreateDomain(const char* name)
 	Exports::mono_assembly_setrootdir(ManagedPathMono);
 	Exports::mono_set_config_dir(MonoConfigPathMono);
 	if (!IsOldMono) {
-		// FIXME: Here is a temporary way to handle command line. Should be done in `CommandLine::Read`.
-		if (CommandLine::argc == 1) {
-			// FIXME: memory leaking
-			// The first one usually is the path of exe which contains non-ASCII charactors, so we only convert it.
-			CommandLine::argv[0] = Encoding::OsToUtf8(CommandLine::argv[0]);
-		}
-		Exports::mono_runtime_set_main_args(CommandLine::argc, CommandLine::argv);
+		Exports::mono_runtime_set_main_args(CommandLine::argc, CommandLine::argvMono);
 	}
 	domain = Exports::mono_jit_init(name);
 	Exports::mono_thread_set_main(Exports::mono_thread_current());

--- a/Bootstrap/Managers/Mono.h
+++ b/Bootstrap/Managers/Mono.h
@@ -19,8 +19,10 @@ public:
 	static Domain* domain;
 	static bool IsOldMono;
 	static char* ManagedPath;
+	static char* ManagedPathMono;
 	static char* ConfigPath;
-	static char* MonoConfigPath;
+	static char* ConfigPathMono;
+	static char* MonoConfigPathMono;
 	static bool Initialize();
 	static bool Load();
 	static bool SetupPaths();

--- a/Bootstrap/Utils/AssemblyGenerator.cpp
+++ b/Bootstrap/Utils/AssemblyGenerator.cpp
@@ -10,7 +10,7 @@
 #include "HashCode.h"
 
 bool AssemblyGenerator::ForceRegeneration = false;
-char* AssemblyGenerator::Path = NULL;
+char* AssemblyGenerator::PathMono = NULL;
 char* AssemblyGenerator::ForceVersion_UnityDependencies = NULL;
 char* AssemblyGenerator::ForceVersion_Dumper = NULL;
 char* AssemblyGenerator::ForceVersion_Il2CppAssemblyUnhollower = NULL;
@@ -28,7 +28,7 @@ bool AssemblyGenerator::Initialize()
 	Console::DisableCloseButton();
 	Debug::Msg("Initializing Assembly Generator...");
 
-	Mono::Assembly* assembly = Mono::Exports::mono_domain_assembly_open(Mono::domain, Path);
+	Mono::Assembly* assembly = Mono::Exports::mono_domain_assembly_open(Mono::domain, PathMono);
 	if (assembly == NULL)
 	{
 		Assertion::ThrowInternalFailure("Failed to Open Assembly Generator!");

--- a/Bootstrap/Utils/AssemblyGenerator.h
+++ b/Bootstrap/Utils/AssemblyGenerator.h
@@ -4,7 +4,7 @@
 class AssemblyGenerator
 {
 public:
-    static char* Path;
+    static char* PathMono;
     static bool ForceRegeneration;
     static char* ForceVersion_UnityDependencies;
     static char* ForceVersion_Dumper;

--- a/Bootstrap/Utils/CommandLine.cpp
+++ b/Bootstrap/Utils/CommandLine.cpp
@@ -5,10 +5,12 @@
 #include "AnalyticsBlocker.h"
 #include "../Managers/InternalCalls.h"
 #include "AssemblyGenerator.h"
+#include "Encoding.h"
 #include "../Managers/Game.h"
 
 int CommandLine::argc = NULL;
 char* CommandLine::argv[64];
+char* CommandLine::argvMono[64];
 IniFile* CommandLine::iniFile = NULL;
 
 void CommandLine::Read()
@@ -18,10 +20,12 @@ void CommandLine::Read()
 	char* curchar = strtok_s(GetCommandLineA(), " ", &nextchar);
 	while (curchar && (argc < 63))
 	{
+		argvMono[argc] = Encoding::OsToUtf8(curchar);
 		argv[argc++] = curchar;
 		curchar = strtok_s(0, " ", &nextchar);
 	}
 	argv[argc] = 0;
+	argvMono[argc] = 0;
 	if (argc <= 0)
 		return;
 	for (int i = 0; i < argc; i++)

--- a/Bootstrap/Utils/CommandLine.h
+++ b/Bootstrap/Utils/CommandLine.h
@@ -7,6 +7,7 @@ class CommandLine
 public:
 	static int argc;
 	static char* argv[64];
+	static char* argvMono[64];
 	static IniFile* iniFile;
 	static void Read();
 	static void ReadIniFile();

--- a/Bootstrap/Utils/Encoding.cpp
+++ b/Bootstrap/Utils/Encoding.cpp
@@ -1,0 +1,38 @@
+#include "Encoding.h"
+
+char* Encoding::OsToUtf8(const char* osStr)
+{
+	// Convert to UTF16
+	int len = MultiByteToWideChar(CP_ACP, 0, osStr, -1, NULL, 0);
+	wchar_t* wstr = new wchar_t[len + 1];
+	memset(wstr, 0, len + 1);
+	MultiByteToWideChar(CP_ACP, 0, osStr, -1, wstr, len);
+
+	// Convert UTF16 to UTF8
+	len = WideCharToMultiByte(CP_UTF8, 0, wstr, -1, NULL, 0, NULL, NULL);
+	char* str = new char[len + 1];
+	memset(str, 0, len + 1);
+	WideCharToMultiByte(CP_UTF8, 0, wstr, -1, str, len, NULL, NULL);
+	
+	delete[] wstr;
+	return str;
+	
+}
+
+char* Encoding::Utf8ToOs(const char* utf8Str)
+{
+	// Convert to UTF16
+	int len = MultiByteToWideChar(CP_UTF8, 0, utf8Str, -1, NULL, 0);
+	wchar_t* wstr = new wchar_t[len + 1];
+	memset(wstr, 0, len * 2 + 2);
+	MultiByteToWideChar(CP_UTF8, 0, utf8Str, -1, wstr, len);
+
+	// Convert to system default encoding
+	len = WideCharToMultiByte(CP_ACP, 0, wstr, -1, NULL, 0, NULL, NULL);
+	char* str = new char[len + 1];
+	memset(str, 0, len + 1);
+	WideCharToMultiByte(CP_ACP, 0, wstr, -1, str, len, NULL, NULL);
+	
+	delete[] wstr;
+	return str;
+}

--- a/Bootstrap/Utils/Encoding.h
+++ b/Bootstrap/Utils/Encoding.h
@@ -1,0 +1,22 @@
+#pragma once
+#include <string>
+#include <Windows.h>
+
+class Encoding
+{
+public:
+    /// <summary>
+    /// Convert system default encoding string to utf8
+    /// </summary>
+    /// <param name="osStr"></param>
+    /// <returns></returns>
+    static char* OsToUtf8(const char* osStr);
+
+    /// <summary>
+    /// Convert utf8 to system default encoding string 
+    /// </summary>
+    /// <param name="utf8Str"></param>
+    /// <returns></returns>
+    static char* Utf8ToOs(const char* utf8Str);
+};
+

--- a/Bootstrap/Utils/HashCode.cpp
+++ b/Bootstrap/Utils/HashCode.cpp
@@ -4,6 +4,7 @@
 #include "../Core.h"
 #include "AssemblyGenerator.h"
 #include "../Managers/BaseAssembly.h"
+#include "../Utils/Encoding.h"
 #include <wincrypt.h>
 #include "Assertion.h"
 #include "Logger.h"
@@ -31,9 +32,9 @@ bool HashCode::SetupPaths()
         Assertion::ThrowInternalFailure("MelonLoader.dll Does Not Exist!");
         return false;
     }
-    BaseAssembly::Path = new char[BaseAssemblyPath.size() + 1];
-    std::copy(BaseAssemblyPath.begin(), BaseAssemblyPath.end(), BaseAssembly::Path);
-    BaseAssembly::Path[BaseAssemblyPath.size()] = '\0';
+    BaseAssembly::PathMono = new char[BaseAssemblyPath.size() + 1];
+    std::copy(BaseAssemblyPath.begin(), BaseAssemblyPath.end(), BaseAssembly::PathMono);
+    BaseAssembly::PathMono[BaseAssemblyPath.size()] = '\0';
 
     if (!Game::IsIl2Cpp)
         return true;
@@ -43,11 +44,18 @@ bool HashCode::SetupPaths()
         Assertion::ThrowInternalFailure("AssemblyGenerator.dll Does Not Exist!");
         return false;
     }
-    AssemblyGenerator::Path = new char[AssemblyGeneratorPath.size() + 1];
-    std::copy(AssemblyGeneratorPath.begin(), AssemblyGeneratorPath.end(), AssemblyGenerator::Path);
-    AssemblyGenerator::Path[AssemblyGeneratorPath.size()] = '\0';
+    AssemblyGenerator::PathMono = new char[AssemblyGeneratorPath.size() + 1];
+    std::copy(AssemblyGeneratorPath.begin(), AssemblyGeneratorPath.end(), AssemblyGenerator::PathMono);
+    AssemblyGenerator::PathMono[AssemblyGeneratorPath.size()] = '\0';
 
-	return true;
+#define TO_UTF8(s) ((s) = Encoding::OsToUtf8((s)))
+    
+    TO_UTF8(AssemblyGenerator::PathMono);
+    TO_UTF8(BaseAssembly::PathMono);
+
+#undef TO_UTF8
+
+    return true;
 }
 
 bool HashCode::GenerateHash(const char* path)

--- a/MelonLoader/Libs/bHaptics/NativeLibrary.cs
+++ b/MelonLoader/Libs/bHaptics/NativeLibrary.cs
@@ -111,7 +111,7 @@ namespace MelonLoader
                 throw new Exception("Unable to Find " + name + " Export!");
             output = Marshal.GetDelegateForFunctionPointer(ptr, typeof(T)) as T;
         }
-        [DllImport("kernel32")]
+        [DllImport("kernel32", CharSet = CharSet.Unicode)]
         private static extern IntPtr LoadLibrary(string lpLibFileName);
         [DllImport("kernel32")]
         private static extern IntPtr GetProcAddress(IntPtr hModule, string lpProcName);


### PR DESCRIPTION
@HerpDerpinstine As we talked in discord, there is an encoding issue in bootstrap caused by mono string encoding convention.

That is the mono requires all strings passed to it must be *valid* UTF8, but the bootstrap just uses the system default codepage(say GBK in cn, CJK in jp) which makes the mono api unsafe to call. So when the string resource(path, filename, etc.) contains some non-ASCII charactors, the melonloader just got crashed.

This PR temporarily covert some path strings to UTF8 to avoid the issue mentioned above, but not fixed it completely(which need a lot of works since it needs us to handle all mono api carafully).