### PR TITLE
Use __argv instead parsing command line manually

### DIFF
--- a/Bootstrap/Utils/CommandLine.cpp
+++ b/Bootstrap/Utils/CommandLine.cpp
@@ -9,28 +9,22 @@
 #include "../Managers/Game.h"
 
 int CommandLine::argc = NULL;
-char* CommandLine::argv[64];
-char* CommandLine::argvMono[64];
+char** CommandLine::argvMono;
 IniFile* CommandLine::iniFile = NULL;
 
 void CommandLine::Read()
 {
 	ReadIniFile();
-	char* nextchar = NULL;
-	char* curchar = strtok_s(GetCommandLineA(), " ", &nextchar);
-	while (curchar && (argc < 63))
-	{
-		argvMono[argc] = Encoding::OsToUtf8(curchar);
-		argv[argc++] = curchar;
-		curchar = strtok_s(0, " ", &nextchar);
-	}
-	argv[argc] = 0;
-	argvMono[argc] = 0;
+
+	argc = __argc;
+	char** argv = __argv;
 	if (argc <= 0)
 		return;
+	argvMono = (char**)malloc(sizeof(argv[0]) * argc);
 	for (int i = 0; i < argc; i++)
 	{
 		const char* command = argv[i];
+		argvMono[i] = Encoding::OsToUtf8(command);
 		if (command == NULL)
 			continue;
 

--- a/Bootstrap/Utils/CommandLine.h
+++ b/Bootstrap/Utils/CommandLine.h
@@ -6,8 +6,7 @@ class CommandLine
 {
 public:
 	static int argc;
-	static char* argv[64];
-	static char* argvMono[64];
+	static char** argvMono;
 	static IniFile* iniFile;
 	static void Read();
 	static void ReadIniFile();


### PR DESCRIPTION
Currently the way to parse command line is by simply splitting it with a space that is wrong according to [this article](https://docs.microsoft.com/en-us/previous-versions/17w5ykft(v=vs.85)) and might lead to an unexpected result when the path contains spaces. For example: `C:\game folder\game.exe` will be parsed to [`C:\game`, `folder\game.exe`] and make the game crash in some cases.
This PR use the [Microsoft extension macro](https://docs.microsoft.com/en-us/cpp/c-runtime-library/argc-argv-wargv?view=msvc-160) `__argv` and `__argc` to get the parsed command line. An alteration could be `CommandLineToArgvW`, but there isn't an ASNI version of it.