### PR TITLE
Make `LogException` read more verbose

### DIFF
--- a/Bootstrap/Managers/Mono.cpp
+++ b/Bootstrap/Managers/Mono.cpp
@@ -48,6 +48,7 @@ MONODEF(mono_class_get_method_from_name)
 MONODEF(mono_string_to_utf8)
 MONODEF(mono_string_new)
 MONODEF(mono_object_get_class)
+MONODEF(mono_object_to_string)
 MONODEF(mono_class_get_property_from_name)
 MONODEF(mono_property_get_get_method)
 MONODEF(mono_free)
@@ -257,6 +258,7 @@ bool Mono::Exports::Initialize()
 	MONODEF(mono_string_to_utf8)
 	MONODEF(mono_string_new)
 	MONODEF(mono_object_get_class)
+	MONODEF(mono_object_to_string)
 	MONODEF(mono_class_get_property_from_name)
 	MONODEF(mono_property_get_get_method)
 	MONODEF(mono_image_get_name)
@@ -302,16 +304,7 @@ void Mono::LogException(Mono::Object* exceptionObject, bool shouldThrow)
 {
 	if (exceptionObject == NULL)
 		return;
-	Class* klass = Exports::mono_object_get_class(exceptionObject);
-	if (klass == NULL)
-		return;
-	Property* prop = Exports::mono_class_get_property_from_name(klass, "Message");
-	if (prop == NULL)
-		return;
-	Method* method = Exports::mono_property_get_get_method(prop);
-	if (method == NULL)
-		return;
-	String* returnstr = (String*)Exports::mono_runtime_invoke(method, exceptionObject, NULL, NULL);
+	String* returnstr = Exports::mono_object_to_string(exceptionObject, NULL);
 	if (returnstr == NULL)
 		return;
 	const char* returnstrc = Exports::mono_string_to_utf8(returnstr);

--- a/Bootstrap/Managers/Mono.h
+++ b/Bootstrap/Managers/Mono.h
@@ -176,6 +176,7 @@ public:
 		MONODEF(char*, mono_string_to_utf8, (String* str))
 		MONODEF(String*, mono_string_new, (Domain* domain, const char* str))
 		MONODEF(Class*, mono_object_get_class, (Object* obj))
+		MONODEF(String*, mono_object_to_string, (Object* obj, Object** exec))
 		MONODEF(Property*, mono_class_get_property_from_name, (Class* klass, const char* name))
 		MONODEF(Method*, mono_property_get_get_method, (Property* prop))
 		MONODEF(void, mono_free, (void* ptr))


### PR DESCRIPTION
Use `ToString` instead `Exception.Message`.
before:
```
[ERROR] The type initializer for 'MelonLoader.AssemblyGenerator.Core' threw an exception.
```
after:
```
[ERROR] System.TypeInitializationException: The type initializer for 'MelonLoader.AssemblyGenerator.Core' threw an exception. ---> System.NullReferenceException: Object reference not set to an instance of an object

  at MelonLoader.AssemblyGenerator.SamboyAPI.Contact () [0x000a0] in <a24f380a6d8a4e729361abc11c8125a2>:0 

  at MelonLoader.AssemblyGenerator.Core..cctor () [0x0010f] in <a24f380a6d8a4e729361abc11c8125a2>:0 

   --- End of inner exception stack trace ---
```