### PR TITLE
Fixes and additions to MelonPreferences

### DIFF
--- a/MelonLoader/Libs/Tomlyn/Syntax/FloatValueSyntax.cs
+++ b/MelonLoader/Libs/Tomlyn/Syntax/FloatValueSyntax.cs
@@ -34,7 +34,7 @@ namespace MelonLoader.Tomlyn.Syntax
             else if (double.IsNegativeInfinity(value))
                 Token = new SyntaxToken(TokenKind.NegativeInfinite, TokenKind.NegativeInfinite.ToText());
             else
-                Token = new SyntaxToken(TokenKind.Float, value.ToString(FloatFormat, CultureInfo.InvariantCulture));
+                Token = new SyntaxToken(TokenKind.Float, ToString(TokenKind.Float, value));
             Value = value;
         }
 

--- a/MelonLoader/MelonLoader.csproj
+++ b/MelonLoader/MelonLoader.csproj
@@ -103,6 +103,7 @@
     <Compile Include="Extensions\Shields\MonoMod\Hook_OnDetour.cs" />
     <Compile Include="Extensions\Shields\MonoMod\ILHook_OnDetour.cs" />
     <Compile Include="Extensions\UnityMagicMethods.cs" />
+    <Compile Include="Preferences\ValueValidator.cs" />
     <Compile Include="Utils\bHaptics\API.cs" />
     <Compile Include="Utils\bHaptics\NativeLibrary.cs" />
     <Compile Include="Libs\HarmonyX\Extras\DelegateTypeFactory.cs" />

--- a/MelonLoader/Preferences/API.cs
+++ b/MelonLoader/Preferences/API.cs
@@ -134,7 +134,7 @@ namespace MelonLoader
         
         public static MelonPreferences_Entry<T> CreateEntry<T>(string category_identifier, string entry_identifier, T default_value, 
             string display_name = null, string description = null, bool is_hidden = false, bool dont_save_default = false, 
-            ValueValidator validator = null)
+            Preferences.ValueValidator validator = null)
         {
             if (string.IsNullOrEmpty(category_identifier))
                 throw new Exception("category_identifier is null or empty when calling CreateEntry");

--- a/MelonLoader/Preferences/API.cs
+++ b/MelonLoader/Preferences/API.cs
@@ -129,19 +129,24 @@ namespace MelonLoader
 
         [Obsolete]
         public static MelonPreferences_Entry CreateEntry<T>(string category_identifier, string entry_identifier,
-            T default_value, string display_name, bool is_hidden) => CreateEntry(category_identifier,
-            entry_identifier, default_value, display_name, is_hidden, false);
+            T default_value, string display_name, bool is_hidden) 
+            => CreateEntry(category_identifier, entry_identifier, default_value, display_name, null, is_hidden, false, null);
         
-        public static MelonPreferences_Entry<T> CreateEntry<T>(string category_identifier, string entry_identifier, T default_value, string display_name = null, bool is_hidden = false, bool dont_save_default = false)
+        public static MelonPreferences_Entry<T> CreateEntry<T>(string category_identifier, string entry_identifier, T default_value, 
+            string display_name = null, string description = null, bool is_hidden = false, bool dont_save_default = false, 
+            ValueValidator validator = null)
         {
             if (string.IsNullOrEmpty(category_identifier))
                 throw new Exception("category_identifier is null or empty when calling CreateEntry");
+
             if (string.IsNullOrEmpty(entry_identifier))
                 throw new Exception("entry_identifier is null or empty when calling CreateEntry");
+
             MelonPreferences_Category category = GetCategory(entry_identifier);
             if (category == null)
                 category = CreateCategory(category_identifier);
-            return category.CreateEntry(entry_identifier, default_value, display_name, is_hidden, dont_save_default);
+
+            return category.CreateEntry(entry_identifier, default_value, display_name, description, is_hidden, dont_save_default, validator);
         }
 
         public static MelonPreferences_Category GetCategory(string identifier)

--- a/MelonLoader/Preferences/Category.cs
+++ b/MelonLoader/Preferences/Category.cs
@@ -22,7 +22,7 @@ namespace MelonLoader
             => CreateEntry(identifier, default_value, display_name, null, is_hidden, false);
 
         public MelonPreferences_Entry<T> CreateEntry<T>(string identifier, T default_value, string display_name = null, 
-            string description = null, bool is_hidden = false, bool dont_save_default = false, ValueValidator validator = null)
+            string description = null, bool is_hidden = false, bool dont_save_default = false, Preferences.ValueValidator validator = null)
         {
             if (string.IsNullOrEmpty(identifier))
                 throw new Exception("identifier is null or empty when calling CreateEntry");

--- a/MelonLoader/Preferences/Category.cs
+++ b/MelonLoader/Preferences/Category.cs
@@ -18,33 +18,45 @@ namespace MelonLoader
         }
 
         [Obsolete]
-        public MelonPreferences_Entry CreateEntry<T>(string identifier, T default_value, string display_name,
-            bool is_hidden) => CreateEntry(identifier, default_value, display_name, is_hidden, false);
-        
-        public MelonPreferences_Entry<T> CreateEntry<T>(string identifier, T default_value, string display_name = null, bool is_hidden = false, bool dont_save_default = false)
+        public MelonPreferences_Entry CreateEntry<T>(string identifier, T default_value, string display_name, bool is_hidden) 
+            => CreateEntry(identifier, default_value, display_name, null, is_hidden, false);
+
+        public MelonPreferences_Entry<T> CreateEntry<T>(string identifier, T default_value, string display_name = null, 
+            string description = null, bool is_hidden = false, bool dont_save_default = false, ValueValidator validator = null)
         {
             if (string.IsNullOrEmpty(identifier))
                 throw new Exception("identifier is null or empty when calling CreateEntry");
+
             if (display_name == null)
                 display_name = identifier;
+
             var entry = GetEntry<T>(identifier);
             if (entry != null)
                 throw new Exception($"Calling CreateEntry for { display_name } when it Already Exists");
+
+            if (validator != null && !validator.IsValid(default_value))
+                throw new ArgumentException($"Default value '{default_value}' is invalid according to the provided ValueValidator!");
+
             entry = new MelonPreferences_Entry<T>
             {
                 Identifier = identifier,
                 DisplayName = display_name,
+                Description = description,
                 IsHidden = is_hidden,
                 DontSaveDefault = dont_save_default,
                 Category = this,
                 DefaultValue = default_value,
-                Value = default_value
+                Value = default_value,
+                Validator = validator,
             };
+
             Preferences.IO.File currentFile = File;
             if (currentFile == null)
                 currentFile = MelonPreferences.DefaultFile;
             currentFile.SetupEntryFromRawValue(entry);
+
             Entries.Add(entry);
+
             return entry;
         }
 

--- a/MelonLoader/Preferences/Entry.cs
+++ b/MelonLoader/Preferences/Entry.cs
@@ -42,11 +42,11 @@ namespace MelonLoader
             get => myValue;
             set
             {
-                if ((myValue == null && value == null) || (myValue != null && myValue.Equals(value)))
-                    return;
-
                 if (Validator != null)
                     value = (T)Validator.EnsureValid(value);
+
+                if ((myValue == null && value == null) || (myValue != null && myValue.Equals(value)))
+                    return;
 
                 var old = myValue;
                 myValue = value;

--- a/MelonLoader/Preferences/Entry.cs
+++ b/MelonLoader/Preferences/Entry.cs
@@ -13,7 +13,7 @@ namespace MelonLoader
         public MelonPreferences_Category Category { get; internal set; }
 
         public abstract object BoxedValue { get; set; }
-        public ValueValidator Validator { get; internal set; }
+        public Preferences.ValueValidator Validator { get; internal set; }
 
         public string GetExceptionMessage(string submsg) 
             => $"Attempted to {submsg} {DisplayName} when it is a {GetReflectedType().FullName}!";
@@ -85,50 +85,5 @@ namespace MelonLoader
             Value = EditedValue;
             return MelonPreferences.Mapper.ToToml(Value);
         }
-    }
-
-    public abstract class ValueValidator
-    {
-        public abstract bool IsValid(object value);
-
-        public abstract object EnsureValid(object value);
-    }
-
-    public interface IValueRange
-    {
-        object MinValue { get; }
-        object MaxValue { get; }
-    }
-    
-    public class ValueRange<T> : ValueValidator, IValueRange where T : IComparable
-    {
-        public T MinValue { get; }
-        public T MaxValue { get; }
-
-        public ValueRange(T minValue, T maxValue)
-        {
-            if (minValue.CompareTo(maxValue) >= 0)
-                throw new ArgumentException($"Min value ({minValue}) must be less than max value ({maxValue})!");
-
-            MinValue = minValue;
-            MaxValue = maxValue;
-        }
-
-        public override bool IsValid(object value)
-        {
-            return MaxValue.CompareTo(value) >= 0 && MinValue.CompareTo(value) <= 0;
-        }
-
-        public override object EnsureValid(object value)
-        {
-            if (MaxValue.CompareTo(value) < 0)
-                return MaxValue;
-            if (MinValue.CompareTo(value) > 0)
-                return MinValue;
-            return value;
-        }
-
-        object IValueRange.MinValue => MinValue;
-        object IValueRange.MaxValue => MaxValue;
     }
 }

--- a/MelonLoader/Preferences/ValueValidator.cs
+++ b/MelonLoader/Preferences/ValueValidator.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace MelonLoader
+{
+    public abstract class ValueValidator
+    {
+        public abstract bool IsValid(object value);
+
+        public abstract object EnsureValid(object value);
+    }
+
+    public interface IValueRange
+    {
+        object MinValue { get; }
+        object MaxValue { get; }
+    }
+
+    public class ValueRange<T> : ValueValidator, IValueRange where T : IComparable
+    {
+        public T MinValue { get; }
+        public T MaxValue { get; }
+
+        public ValueRange(T minValue, T maxValue)
+        {
+            if (minValue.CompareTo(maxValue) >= 0)
+                throw new ArgumentException($"Min value ({minValue}) must be less than max value ({maxValue})!");
+
+            MinValue = minValue;
+            MaxValue = maxValue;
+        }
+
+        public override bool IsValid(object value)
+        {
+            return MaxValue.CompareTo(value) >= 0 && MinValue.CompareTo(value) <= 0;
+        }
+
+        public override object EnsureValid(object value)
+        {
+            if (MaxValue.CompareTo(value) < 0)
+                return MaxValue;
+            if (MinValue.CompareTo(value) > 0)
+                return MinValue;
+            return value;
+        }
+
+        object IValueRange.MinValue => MinValue;
+        object IValueRange.MaxValue => MaxValue;
+    }
+}

--- a/MelonLoader/Preferences/ValueValidator.cs
+++ b/MelonLoader/Preferences/ValueValidator.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
-namespace MelonLoader
+namespace MelonLoader.Preferences
 {
     public abstract class ValueValidator
     {


### PR DESCRIPTION
* Force including decimal point when serializing floats. With previous implementation they could be rounded to an integer and the deserialization of float arrays would fail. (eg, try to load a saved Color setting with the value `1, 0.5, 0.5`, it treats the first value as integer and fails).
* Added `MelonPreferences_Entry.Description` for use with external API
* Added `MelonPreferences_Entry.BoxedValue` to access the value without generic arguments
* Added `MelonPreferences_Entry.Validator` and `ValueValidator` class. Currently just implemented `ValueRange` but its extendable for other purposes too.
* Added an early-out to `MelonPreferences_Entry.set_Value` if the value is equal to the current value (to prevent callback loops).