### PR TITLE
Add OnApplicationEarlyStart (Plugins), move Il2CppAssemblyUnhollower between OnApplicationEarlyStart and OnApplicationStart

### DIFF
--- a/Bootstrap/Managers/BaseAssembly.h
+++ b/Bootstrap/Managers/BaseAssembly.h
@@ -8,8 +8,10 @@ public:
 	static char* PreloadPath;
 	static bool Initialize();
 	static void Preload();
+	static bool PreStart();
 	static void Start();
 
 private:
+	static Mono::Method* Mono_PreStart;
 	static Mono::Method* Mono_Start;
 };

--- a/Bootstrap/Managers/Il2Cpp.cpp
+++ b/Bootstrap/Managers/Il2Cpp.cpp
@@ -109,7 +109,8 @@ Il2Cpp::Object* Il2Cpp::Hooks::il2cpp_runtime_invoke(Method* method, Object* obj
 	{
 		Debug::Msg("Detaching Hook from il2cpp_runtime_invoke...");
 		Hook::Detach(&(LPVOID&)Exports::il2cpp_runtime_invoke, il2cpp_runtime_invoke);
-		BaseAssembly::Start();
+		if (BaseAssembly::PreStart())
+			BaseAssembly::Start();
 	}
 	return Exports::il2cpp_runtime_invoke(method, obj, params, exec);
 }

--- a/MelonLoader/Core.cs
+++ b/MelonLoader/Core.cs
@@ -33,6 +33,13 @@ namespace MelonLoader
             MelonHandler.LoadPlugins();
             MelonHandler.OnPreInitialization();
 
+            return 0;
+        }
+
+        private static int PreStart()
+        {
+            MelonHandler.OnApplicationEarlyStart();
+
             if (!Il2CppAssemblyGenerator.Run())
                 return 1;
 

--- a/MelonLoader/Melons/Handler.cs
+++ b/MelonLoader/Melons/Handler.cs
@@ -384,6 +384,7 @@ namespace MelonLoader
         }
 
         internal static void OnPreInitialization() => InvokeMelonPluginMethod(x => x.OnPreInitialization(), true);
+        internal static void OnApplicationEarlyStart() => InvokeMelonPluginMethod(x => x.OnApplicationEarlyStart(), true);
         internal static void OnApplicationStart_Plugins() => InvokeMelonPluginMethod(x => x.OnApplicationStart(), true);
         internal static void OnApplicationStart_Mods() => InvokeMelonModMethod(x => x.OnApplicationStart(), true);
         internal static void OnApplicationLateStart_Plugins() => InvokeMelonPluginMethod(x => x.OnApplicationLateStart(), true);

--- a/MelonLoader/Melons/Plugin.cs
+++ b/MelonLoader/Melons/Plugin.cs
@@ -11,6 +11,11 @@ namespace MelonLoader
         /// </summary>
         public virtual void OnPreInitialization() { }
 
+        /// <summary>
+        /// Runs after Game Initialization, before OnApplicationStart and (on Il2Cpp games) before Unhollower
+        /// </summary>
+        public virtual void OnApplicationEarlyStart() { }
+
         [Obsolete()]
         private MelonPluginInfoAttribute _LegacyInfoAttribute = null;
         [Obsolete("MelonPlugin.InfoAttribute is obsolete. Please use MelonBase.Info instead.")]


### PR DESCRIPTION
Actual full changes:
 - Unhollower is now called from `Il2Cpp::Hooks::il2cpp_runtime_invoke`, which is a bit later but doesn't matter much since nothing was called before (Except the Plugins `OnPreInitialization`, but those were already called before Unhollower's setup/run.
 - In `Il2Cpp::Hooks::il2cpp_runtime_invoke`, `BaseAssembly::Start` is only called if `BaseAssembly::PreStart` succeed, because we don't want it to run w/o Unhollower I suppose
 
Also, I was unable to check the Harmony auto-patching part. I guess it works, but it may be called before unhollower depending on where it is in the code