### PR TITLE
Fix extracting downloaded zip files

### DIFF
--- a/MelonLoader.AssemblyGenerator/DownloaderAndUnpacker.cs
+++ b/MelonLoader.AssemblyGenerator/DownloaderAndUnpacker.cs
@@ -26,17 +26,8 @@ namespace MelonLoader.AssemblyGenerator
             Logger.Log($"Downloading {url} to {tempFile}");
             Program.webClient.DownloadFile(url, tempFile);
             Logger.Log($"Extracting {tempFile} to {destinationFolder}");
-            
-            using var stream = new FileStream(tempFile, FileMode.Open, FileAccess.Read);
-            using var zip = new ZipArchive(stream);
-            
-            foreach (var zipArchiveEntry in zip.Entries)
-            {
-                Logger.Log($"Extracting {zipArchiveEntry.FullName}");
-                using var entryStream = zipArchiveEntry.Open();
-                using var targetStream = new FileStream(Path.Combine(destinationFolder, zipArchiveEntry.FullName), FileMode.OpenOrCreate, FileAccess.Write);
-                entryStream.CopyTo(targetStream);
-            }
+
+            ZipFile.ExtractToDirectory(tempFile, destinationFolder);
         }
     }
 }

--- a/MelonLoader.AssemblyGenerator/MelonLoader.AssemblyGenerator.csproj
+++ b/MelonLoader.AssemblyGenerator/MelonLoader.AssemblyGenerator.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -52,6 +52,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.IO.Compression" />
+    <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.IO.Compression.ZipFile" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />


### PR DESCRIPTION
Previously it would fail if the archive contained any directories. I don't believe there should be a reason for using a custom implementation vs simply `ZipFile.ExtractToDirectory`
```
Downloading https://github.com/HerpDerpinstine/MelonLoader/raw/master/BaseLibs/UnityDependencies/2019.4.21.zip to C:\Users\Extacy\AppData\Local\Temp\tmp2475.tmp
Extracting C:\Users\Extacy\AppData\Local\Temp\tmp2475.tmp to C:\Users\Extacy\Documents\RealmOfTheMadGod\Production\MelonLoader\Dependencies\AssemblyGenerator\UnityDependencies
Extracting 2019.4.21/
System.IO.IOException: The filename, directory name, or volume label syntax is incorrect.

   at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   at System.IO.FileStream.Init(String path, FileMode mode, FileAccess access, Int32 rights, Boolean useRights, FileShare share, Int32 bufferSize, FileOptions options, SECURITY_ATTRIBUTES secAttrs, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolean checkHost)
   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access)
   at MelonLoader.AssemblyGenerator.DownloaderAndUnpacker.Run(String url, String targetVersion, String currentVersion, String destinationFolder, String tempFile) in C:\Users\Extacy\source\repos\MelonLoader\MelonLoader.AssemblyGenerator\DownloaderAndUnpacker.cs:line 39
   at MelonLoader.AssemblyGenerator.Main.DownloadDependencies(String unityVersion) in C:\Users\Extacy\source\repos\MelonLoader\MelonLoader.AssemblyGenerator\AssemblyGenerator.cs:line 127
   ```