### PR TITLE
Compatibility Fix with the upcoming Unhollower 0.4.15.0

### DIFF
--- a/MelonLoader/Extensions/Il2CppMethodPatcher.cs
+++ b/MelonLoader/Extensions/Il2CppMethodPatcher.cs
@@ -42,7 +42,7 @@ namespace MelonLoader
 		private HarmonyIl2CppMethodPatcher(MethodBase original) : base(original)
 		{
 			originalMethodInfoPointer = UnhollowerSupport.MethodBaseToIl2CppMethodInfoPointer(Original);
-			copiedMethodInfoPointer = CopyMethodInfoStruct(originalMethodInfoPointer);
+			copiedMethodInfoPointer = (IntPtr)UnhollowerSupport.CopyMethodInfoStructMethod.Invoke(null, new object[] { originalMethodInfoPointer });
 		}
 
 		public override MethodBase DetourTo(MethodBase replacement)
@@ -97,19 +97,6 @@ namespace MelonLoader
 			ilcursor.Emit(Mono.Cecil.Cil.OpCodes.Ldc_I8, copiedMethodInfoPointer.ToInt64());
 			ilcursor.Emit(Mono.Cecil.Cil.OpCodes.Conv_I);
 			return method;
-		}
-
-		private IntPtr CopyMethodInfoStruct(IntPtr origMethodInfo)
-		{
-			// Il2CppMethodInfo *copiedMethodInfo = malloc(sizeof(Il2CppMethodInfo));
-			int sizeOfMethodInfo = Marshal.SizeOf(UnhollowerSupport.Il2CppMethodInfoType);
-			IntPtr copiedMethodInfo = Marshal.AllocHGlobal(sizeOfMethodInfo);
-
-			// *copiedMethodInfo = *origMethodInfo;
-			object temp = Marshal.PtrToStructure(origMethodInfo, UnhollowerSupport.Il2CppMethodInfoType);
-			Marshal.StructureToPtr(temp, copiedMethodInfo, false);
-
-			return copiedMethodInfo;
 		}
 
 		private DynamicMethodDefinition CreateIl2CppShim(MethodInfo patch)

--- a/MelonLoader/Utils/UnhollowerSupport.cs
+++ b/MelonLoader/Utils/UnhollowerSupport.cs
@@ -8,7 +8,7 @@ namespace MelonLoader
     {
         internal static Type IL2CPPType = null;
         internal static Type Il2CppObjectBaseType = null;
-        internal static Type Il2CppMethodInfoType = null;
+        internal static MethodInfo CopyMethodInfoStructMethod = null;
         internal static MethodInfo Il2CppObjectBaseToPtrMethod = null;
         internal static MethodInfo Il2CppStringToManagedMethod = null;
         internal static MethodInfo ManagedStringToIl2CppMethod = null;
@@ -29,7 +29,7 @@ namespace MelonLoader
             }
             IL2CPPType = UnhollowerBaseLib.GetType("UnhollowerBaseLib.IL2CPP");
             Il2CppObjectBaseType = UnhollowerBaseLib.GetType("UnhollowerBaseLib.Il2CppObjectBase");
-            Il2CppMethodInfoType = UnhollowerBaseLib.GetType("UnhollowerBaseLib.Runtime.Il2CppMethodInfo");
+            CopyMethodInfoStructMethod = UnhollowerBaseLib.GetType("UnhollowerBaseLib.Runtime.UnityVersionHandler").GetMethod("CopyMethodInfoStruct");
             Il2CppObjectBaseToPtrMethod = IL2CPPType.GetMethod("Il2CppObjectBaseToPtr");
             Il2CppStringToManagedMethod = IL2CPPType.GetMethod("Il2CppStringToManaged");
             ManagedStringToIl2CppMethod = IL2CPPType.GetMethod("ManagedStringToIl2Cpp");


### PR DESCRIPTION
This pull request fixes a minor incompatibility between MelonLoader and the upcoming version of Unhollower.

Without this fix, MelonLoader crashes when trying to apply Harmony Patches for Il2Cpp games.

This has a [partner pull request](https://github.com/knah/Il2CppAssemblyUnhollower/pull/39) on the [Unhollower repository](https://github.com/knah/Il2CppAssemblyUnhollower).