### PR TITLE
Add dnSpy debugger option

### DIFF
--- a/Bootstrap/Managers/Mono.cpp
+++ b/Bootstrap/Managers/Mono.cpp
@@ -29,6 +29,7 @@ bool Mono::IsOldMono = false;
 
 MONODEF(mono_jit_init)
 MONODEF(mono_jit_init_version)
+MONODEF(mono_jit_parse_options)
 MONODEF(mono_set_assemblies_path)
 MONODEF(mono_assembly_setrootdir)
 MONODEF(mono_set_config_dir)
@@ -220,7 +221,10 @@ void Mono::CreateDomain(const char* name)
 		Exports::mono_runtime_set_main_args(CommandLine::argc, CommandLine::argvMono);
 
 	if (Debug::Enabled)
+	{
+		Mono::ParseEnvOption("DNSPY_UNITY_DBG2");
 		Exports::mono_debug_init(MONO_DEBUG_FORMAT_MONO);
+	}
 
 	domain = Exports::mono_jit_init(name);
 
@@ -256,6 +260,7 @@ bool Mono::Exports::Initialize()
 	#define MONODEF(fn) fn = (fn##_t) Assertion::GetExport(Module, #fn);
 
 	MONODEF(mono_jit_init)
+	MONODEF(mono_jit_parse_options)
 	MONODEF(mono_thread_set_main)
 	MONODEF(mono_thread_current)
 	MONODEF(mono_add_internal_call)
@@ -340,6 +345,18 @@ void Mono::LogException(Mono::Object* exceptionObject, bool shouldThrow)
 	Free(returnstr);
 }
 
+void Mono::ParseEnvOption(const char* name)
+{
+	const int size = 1024;
+	char env[size];
+	DWORD length = GetEnvironmentVariableA(name, env, size);
+	if (length > 0 && length < size)
+	{
+		char* options[1] = { env };
+		Exports::mono_jit_parse_options(1, options);
+	}
+}
+
 Mono::Domain* Mono::Hooks::mono_jit_init_version(const char* name, const char* version)
 {
 	Console::SetHandles();
@@ -348,7 +365,10 @@ Mono::Domain* Mono::Hooks::mono_jit_init_version(const char* name, const char* v
 	Debug::Msg("Creating Mono Domain...");
 
 	if (Debug::Enabled)
+	{
+		Mono::ParseEnvOption("DNSPY_UNITY_DBG2");
 		Exports::mono_debug_init(MONO_DEBUG_FORMAT_MONO);
+	}
 
 	domain = Exports::mono_jit_init_version(name, version);
 

--- a/Bootstrap/Managers/Mono.h
+++ b/Bootstrap/Managers/Mono.h
@@ -166,6 +166,7 @@ public:
 
 		MONODEF(Domain*, mono_jit_init, (const char* name))
 		MONODEF(Domain*, mono_jit_init_version, (const char* name, const char* version))
+		MONODEF(void*, mono_jit_parse_options, (int argc, char* argv[]))
 		MONODEF(void, mono_set_assemblies_path, (const char* path))
 		MONODEF(void, mono_assembly_setrootdir, (const char* path))
 		MONODEF(void, mono_set_config_dir, (const char* path))
@@ -223,4 +224,6 @@ private:
 	static const char* LibNames[];
 	static const char* FolderNames[];
 	static HMODULE PosixHelper;
+
+	static void ParseEnvOption(const char* name);
 };


### PR DESCRIPTION
dnSpy passes its debugger option by setting the environment variable DNSPY_UNITY_DBG2.