### PR TITLE
Fix a rare NRE in Il2CppAssemblyGenerator.RemoteAPI.ContactHosts

### DIFF
--- a/Il2CppAssemblyGenerator/RemoteAPI.cs
+++ b/Il2CppAssemblyGenerator/RemoteAPI.cs
@@ -69,7 +69,7 @@ namespace MelonLoader.Il2CppAssemblyGenerator
                 try { Response = Core.webClient.DownloadString(pair.Key); }
                 catch (Exception ex)
                 {
-                    if (!(ex is System.Net.WebException))
+                    if (!(ex is System.Net.WebException) || ((System.Net.WebException) ex).Response == null)
                     {
                         MelonLogger.Error($"Exception while Contacting RemoteAPI Host ({pair.Key}): {ex}");
                         continue;


### PR DESCRIPTION
In ContactHosts, in the exception handler at [line 97](https://github.com/LavaGang/MelonLoader/blob/d8c01f93f87317432357a9624f8d78166c2b60ed/Il2CppAssemblyGenerator/RemoteAPI.cs#L79), `response` may be null if no response was received, e.g. due to the error on the user's PC. In that case, that catch block would throw another exception, and the actual `WebException` we care about to diagnose the issue is lost.