### PR TITLE
Disable colour in cpp2il

### DIFF
--- a/Il2CppAssemblyGenerator/Packages/Base.cs
+++ b/Il2CppAssemblyGenerator/Packages/Base.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
@@ -88,7 +89,7 @@ namespace MelonLoader.Il2CppAssemblyGenerator
             Directory.Delete(Output, true);
         }
 
-        internal bool Execute(string[] args, bool parenthesize_args = true)
+        internal bool Execute(string[] args, bool parenthesize_args = true, Dictionary<string, string> environment = null)
         {
             if (!Directory.Exists(Output))
                 Directory.CreateDirectory(Output);
@@ -113,6 +114,14 @@ namespace MelonLoader.Il2CppAssemblyGenerator
                 processStartInfo.RedirectStandardError = true;
                 processStartInfo.CreateNoWindow = true;
                 processStartInfo.WorkingDirectory = Path.GetDirectoryName(ExePath);
+
+                if (environment != null)
+                {
+                    foreach (var kvp in environment)
+                    {
+                        processStartInfo.EnvironmentVariables[kvp.Key] = kvp.Value;
+                    }
+                }
 
                 MelonLogger.Msg("\"" + ExePath + "\" " + processStartInfo.Arguments);
 

--- a/Il2CppAssemblyGenerator/Packages/Cpp2IL.cs
+++ b/Il2CppAssemblyGenerator/Packages/Cpp2IL.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 
 namespace MelonLoader.Il2CppAssemblyGenerator
 {
@@ -56,7 +57,9 @@ namespace MelonLoader.Il2CppAssemblyGenerator
                 "--skip-analysis",
                 "--skip-metadata-txts",
                 "--disable-registration-prompts"
-            }, false);
+            }, false, new Dictionary<string, string>() {
+                {"NO_COLOR", "1"}
+            });
         }
     }
 }


### PR DESCRIPTION
This PR adds support for setting environment variables in assembly generator packages, and uses that functionality to disable colours in Cpp2IL. While they may be nice in standalone output, the log files written by MelonLoader contain the ANSI colour control codes, and this is not desirable.

Therefore, the colour functionality is disabled by setting NO_COLOR=1.