### PR TITLE
Add Mod Name Sorting

### DIFF
--- a/MelonLoader/Melons/Handler.cs
+++ b/MelonLoader/Melons/Handler.cs
@@ -88,7 +88,10 @@ namespace MelonLoader
             MelonLogger.Msg($"{melontbl.Length} {(is_plugins ? "Plugin" : "Mod")}{((_Mods.Count > 1) ? "s" : "")} Loaded");
             MelonLogger.Msg("------------------------------");
 
-            foreach (MelonBase melon in melontbl)
+            List<MelonBase> melontblList = new List<MelonBase>(melontbl);
+            melontblList.Sort((MelonBase left, MelonBase right) => string.Compare(left.Info.Name, right.Info.Name));
+
+            foreach (MelonBase melon in melontblList)
             {
                 MelonLogger.Internal_PrintModName(melon.ConsoleColor, melon.Info.Name, melon.Info.Version);
 


### PR DESCRIPTION
This pull request implements sorting for mod names when printing the melon info at launch. This makes the log significantly more readable since the mods are in alphabetical order instead of load order.