### PR TITLE
Remove null check in MelonLoader.FileTypes.DLL.LoadFromByteArray

### DIFF
--- a/MelonLoader/FileTypes/DLL.cs
+++ b/MelonLoader/FileTypes/DLL.cs
@@ -71,7 +71,7 @@ namespace MelonLoader.FileTypes
             }
             else
             {
-                byte[] symbolsdata = new byte[0];
+                byte[] symbolsdata = null;
                 if (string.IsNullOrEmpty(symbolspath))
                     symbolspath = Path.Combine(Path.GetDirectoryName(filepath), $"{Path.GetFileNameWithoutExtension(filepath)}.mdb");
                 if (!File.Exists(symbolspath))
@@ -112,7 +112,7 @@ namespace MelonLoader.FileTypes
             Assembly melonassembly = null;
             try
             {
-                melonassembly = Assembly.Load(filedata, symbolsdata ?? new byte[0]);
+                melonassembly = Assembly.Load(filedata, symbolsdata);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Fixes crash when loading assemblies in old Mono on x86 arch.