### PR TITLE
Fixed occassional double-logging issue

### DIFF
--- a/Bootstrap/Bootstrap.vcxproj
+++ b/Bootstrap/Bootstrap.vcxproj
@@ -199,7 +199,8 @@
     <ClCompile Include="Utils\Encoding.cpp" />
     <ClCompile Include="Utils\HashCode.cpp" />
     <ClCompile Include="Utils\IniFile.cpp" />
-    <ClCompile Include="Utils\Logger.cpp" />
+    <ClCompile Include="Utils\Logging\Log.cpp" />
+    <ClCompile Include="Utils\Logging\Logger.cpp" />
     <ClCompile Include="Utils\PointerUtils.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -224,7 +225,8 @@
     <ClInclude Include="Utils\Encoding.h" />
     <ClInclude Include="Utils\HashCode.h" />
     <ClInclude Include="Utils\IniFile.h" />
-    <ClInclude Include="Utils\Logger.h" />
+    <ClInclude Include="Utils\Logging\Log.h" />
+    <ClInclude Include="Utils\Logging\Logger.h" />
     <ClInclude Include="Utils\PointerUtils.h" />
   </ItemGroup>
   <ItemGroup>

--- a/Bootstrap/Core.cpp
+++ b/Bootstrap/Core.cpp
@@ -11,7 +11,7 @@
 #include "Utils/CommandLine.h"
 #include "Utils/Console.h"
 #include "Utils/Assertion.h"
-#include "Utils/Logger.h"
+#include "Utils/Logging/Logger.h"
 #include "Utils/Debug.h"
 #include "Utils/AnalyticsBlocker.h"
 #include "Utils/HashCode.h"

--- a/Bootstrap/Managers/BaseAssembly.cpp
+++ b/Bootstrap/Managers/BaseAssembly.cpp
@@ -4,7 +4,7 @@
 #include "Game.h"
 #include <string>
 #include "../Utils/Assertion.h"
-#include "../Utils/Logger.h"
+#include "../Utils/Logging/Logger.h"
 #include "../Utils/Il2CppAssemblyGenerator.h"
 
 char* BaseAssembly::PathMono = NULL;

--- a/Bootstrap/Managers/Game.cpp
+++ b/Bootstrap/Managers/Game.cpp
@@ -6,7 +6,7 @@
 #include "../Core.h"
 #include "Il2Cpp.h"
 #include "../Utils/Assertion.h"
-#include "../Utils/Logger.h"
+#include "../Utils/Logging/Logger.h"
 #include "../Utils/Encoding.h"
 #pragma comment(lib,"version.lib")
 

--- a/Bootstrap/Managers/InternalCalls.cpp
+++ b/Bootstrap/Managers/InternalCalls.cpp
@@ -1,6 +1,6 @@
 #include "InternalCalls.h"
 #include "../Utils/Debug.h"
-#include "../Utils/Logger.h"
+#include "../Utils/Logging/Logger.h"
 #include "Game.h"
 #include "Hook.h"
 #include "../Utils/Assertion.h"

--- a/Bootstrap/Managers/Mono.cpp
+++ b/Bootstrap/Managers/Mono.cpp
@@ -10,7 +10,7 @@
 #include "InternalCalls.h"
 #include "BaseAssembly.h"
 #include "Il2Cpp.h"
-#include "../Utils/Logger.h"
+#include "../Utils/Logging/Logger.h"
 
 const char* Mono::LibNames[] = { "mono", "mono-2.0-bdwgc", "mono-2.0-sgen", "mono-2.0-boehm" };
 const char* Mono::FolderNames[] = { "Mono", "MonoBleedingEdge", "MonoBleedingEdge.x86", "MonoBleedingEdge.x64" };

--- a/Bootstrap/Utils/Assertion.cpp
+++ b/Bootstrap/Utils/Assertion.cpp
@@ -1,7 +1,7 @@
 #include "Assertion.h"
 #include "../Core.h"
 #include "Debug.h"
-#include "Logger.h"
+#include "Logging/Logger.h"
 #include "Console.h"
 #include "../Managers/Game.h"
 #include <string>

--- a/Bootstrap/Utils/CommandLine.cpp
+++ b/Bootstrap/Utils/CommandLine.cpp
@@ -1,5 +1,5 @@
 #include "CommandLine.h"
-#include "Logger.h"
+#include "Logging/Logger.h"
 #include "Debug.h"
 #include "AnalyticsBlocker.h"
 #include "Encoding.h"

--- a/Bootstrap/Utils/Console.cpp
+++ b/Bootstrap/Utils/Console.cpp
@@ -7,7 +7,7 @@
 #include <locale.h>
 #include "../Managers/Game.h"
 #include "Il2CppAssemblyGenerator.h"
-#include "Logger.h"
+#include "Logging/Logger.h"
 #include <sstream>
 #include <VersionHelpers.h>
 

--- a/Bootstrap/Utils/Debug.cpp
+++ b/Bootstrap/Utils/Debug.cpp
@@ -1,5 +1,5 @@
 #include "Debug.h"
-#include "Logger.h"
+#include "Logging/Logger.h"
 #include "Assertion.h"
 
 bool Debug::Enabled = false;
@@ -13,7 +13,7 @@ void Debug::Msg(const char* txt)
 
 void Debug::DirectWrite(const char* txt)
 {
-	Log(LogType::Debug, nullptr, txt).LogToConsoleAndFile();
+	Logger::LogToConsoleAndFile(Log(LogType::Debug, nullptr, txt));
 }
 
 void Debug::Internal_Msg(Console::Color meloncolor, Console::Color txtcolor, const char* namesection, const char* txt)
@@ -21,5 +21,5 @@ void Debug::Internal_Msg(Console::Color meloncolor, Console::Color txtcolor, con
 	if (!Enabled || !Assertion::ShouldContinue)
 		return;
 
-	Log(LogType::Debug, meloncolor, txtcolor, namesection, txt).LogToConsoleAndFile();
+	Logger::LogToConsoleAndFile(Log(LogType::Debug, meloncolor, txtcolor, namesection, txt));
 }

--- a/Bootstrap/Utils/HashCode.cpp
+++ b/Bootstrap/Utils/HashCode.cpp
@@ -7,7 +7,7 @@
 #include "../Utils/Encoding.h"
 #include <wincrypt.h>
 #include "Assertion.h"
-#include "Logger.h"
+#include "Logging/Logger.h"
 #include <sstream>
 
 std::string HashCode::Hash;

--- a/Bootstrap/Utils/Logging/Log.cpp
+++ b/Bootstrap/Utils/Logging/Log.cpp
@@ -1,0 +1,39 @@
+﻿#include "Log.h"
+
+#include "Logger.h"
+
+void Log::BuildConsoleString(std::ostream& stream) const
+{
+    // Always initialize stream with timestamp
+    stream << 
+        Console::ColorToAnsi(logMeta->GetColorOverride(Console::Color::Gray)) <<
+        "[" <<
+        Console::ColorToAnsi(logMeta->GetColorOverride(Console::Color::Green)) <<
+        Logger::GetTimestamp() <<
+        Console::ColorToAnsi(logMeta->GetColorOverride(Console::Color::Gray)) <<
+        "] ";
+
+    // If the logging melon has a name, print it
+    if (namesection != nullptr) stream << "[" <<
+        Console::ColorToAnsi(melonAnsiColor) <<
+        namesection <<
+        Console::ColorToAnsi(logMeta->GetColorOverride(Console::Color::Gray)) <<
+        "] ";
+
+    // Print the [LOGTYPE] prefix if needed
+    if (logMeta->printLogTypeName) stream << "[" << Console::ColorToAnsi(logMeta->logCategoryColor) << logMeta->logTypeString << Console::ColorToAnsi(logMeta->GetColorOverride(Console::Color::Gray)) << "] ";
+
+    // If we're not coloring the whole line, use the specified input text color. If we are, the color would already be declared
+    if (!logMeta->colorFullLine) stream << Console::ColorToAnsi(textAnsiColor);
+	
+    stream << txt <<
+        Console::ColorToAnsi(logMeta->GetColorOverride(Console::Color::Gray), false);
+}
+
+std::string Log::BuildLogString() const
+{
+    std::string logStr = "[" + Logger::GetTimestamp() + "] ";
+    if (namesection != nullptr)	logStr = logStr + "[" + namesection + "] ";
+    if (logMeta->printLogTypeName) logStr = logStr + "[" + logMeta->logTypeString + "] ";
+    return logStr + txt;
+}

--- a/Bootstrap/Utils/Logging/Log.h
+++ b/Bootstrap/Utils/Logging/Log.h
@@ -1,10 +1,6 @@
-#pragma once
-#include <fstream>
-#include <filesystem>
-#include <iostream>
-#include <string>
-#include "Console.h"
-
+﻿#pragma once
+#include <ostream>
+#include "../Console.h"
 
 enum LogType
 {
@@ -39,7 +35,7 @@ static std::pair<LogType, LogMeta*> LogTypes[] = {
 	std::make_pair<LogType, LogMeta*>(Msg, new LogMeta("DEBUG", false, Console::Color::Blue))
 };
 
-class Log
+struct Log
 {
 	LogMeta* logMeta;
 	
@@ -48,7 +44,6 @@ class Log
 	const char* namesection;
 	const char* txt;
 	
-public:
 	Log(const LogType type, const Console::Color meloncolor, const Console::Color txtcolor, const char* namesection, const char* txt) :
 	logMeta(LogTypes[type].second),
 	melonAnsiColor(logMeta->GetColorOverride(meloncolor)),	// If the log meta says we need to color the whole string,
@@ -63,48 +58,4 @@ public:
 
 	void BuildConsoleString(std::ostream& stream) const;	// Constructs a string with color to print to the console (Doesn't include linebreak)
 	std::string BuildLogString() const;	// Constructs a string without color to log to file (Doesn't include linebreak)
-
-	void LogToConsoleAndFile() const;	// Shorthand way to log to console and write to file with linebreak afterwards
-};
-
-class Logger
-{
-public:
-	static int MaxLogs;
-	static int MaxWarnings;
-	static int MaxErrors;
-	static bool Initialize();
-	static std::string GetTimestamp();
-	static void WriteSpacer();
-
-	static void Internal_PrintModName(Console::Color meloncolor, const char* name, const char* version);
-	
-	static void QuickLog(const char* txt, LogType logType = Msg)	// Like std::cout but prepends timestamp and appends to logfile
-	{Log(logType, nullptr, txt).LogToConsoleAndFile();}
-	
-	static void Internal_Msg(Console::Color meloncolor, Console::Color txtcolor, const char* namesection, const char* txt);
-	static void Internal_Warning(const char* namesection, const char* txt);
-	static void Internal_Error(const char* namesection, const char* txt);
-
-	class FileStream
-	{
-	public:
-		std::ofstream coss;
-		std::ofstream latest;
-		template <class T>
-		FileStream& operator<< (T val) { if (coss.is_open()) coss << val; if (latest.is_open()) latest << val; return *this; }
-		FileStream& operator<< (std::ostream& (*pfun)(std::ostream&)) { if (coss.is_open()) pfun(coss); if (latest.is_open()) pfun(latest); return *this; }
-		void Flush() { if (coss.is_open()) coss.flush(); if (latest.is_open()) latest.flush(); }
-	};
-	static FileStream LogFile;
-	static void Flush() { LogFile.Flush(); }
-
-	static const char* LatestLogFileName;
-	static const char* FileExtension;
-private:
-	static const char* FilePrefix;
-	static int WarningCount;
-	static int ErrorCount;
-	static void CleanOldLogs(const char* path);
-	static bool CompareWritetime(const std::filesystem::directory_entry& first, const std::filesystem::directory_entry& second) { return first.last_write_time().time_since_epoch() >= second.last_write_time().time_since_epoch(); }
 };

--- a/Bootstrap/Utils/Logging/Log.h
+++ b/Bootstrap/Utils/Logging/Log.h
@@ -30,9 +30,9 @@ struct LogMeta
 // Declares metadata for logs
 static std::pair<LogType, LogMeta*> LogTypes[] = {
 	std::make_pair<LogType, LogMeta*>(Msg, new LogMeta()),
-	std::make_pair<LogType, LogMeta*>(Msg, new LogMeta("WARNING", true, Console::Color::Yellow)),
-	std::make_pair<LogType, LogMeta*>(Msg, new LogMeta("ERROR", true, Console::Color::Red)),
-	std::make_pair<LogType, LogMeta*>(Msg, new LogMeta("DEBUG", false, Console::Color::Blue))
+	std::make_pair<LogType, LogMeta*>(Warning, new LogMeta("WARNING", true, Console::Color::Yellow)),
+	std::make_pair<LogType, LogMeta*>(Error, new LogMeta("ERROR", true, Console::Color::Red)),
+	std::make_pair<LogType, LogMeta*>(Debug, new LogMeta("DEBUG", false, Console::Color::Blue))
 };
 
 struct Log

--- a/Bootstrap/Utils/Logging/Logger.h
+++ b/Bootstrap/Utils/Logging/Logger.h
@@ -10,6 +10,9 @@
 
 class Logger
 {
+	static std::mutex logMutex;
+	
+public:
 	static int MaxLogs;
 	static int MaxWarnings;
 	static int MaxErrors;
@@ -17,9 +20,6 @@ class Logger
 	static int WarningCount;
 	static int ErrorCount;
 	
-	static std::mutex logMutex;
-	
-public:
 	static bool Initialize();
 	static std::string GetTimestamp();
 	static void WriteSpacer();

--- a/Bootstrap/Utils/Logging/Logger.h
+++ b/Bootstrap/Utils/Logging/Logger.h
@@ -1,0 +1,60 @@
+#pragma once
+#include <fstream>
+#include <filesystem>
+#include <iostream>
+#include <mutex>
+#include <string>
+#include "../Console.h"
+#include "Log.h"
+
+
+class Logger
+{
+	static int MaxLogs;
+	static int MaxWarnings;
+	static int MaxErrors;
+	
+	static int WarningCount;
+	static int ErrorCount;
+	
+	static std::mutex logMutex;
+	
+public:
+	static bool Initialize();
+	static std::string GetTimestamp();
+	static void WriteSpacer();
+
+	static void Internal_PrintModName(Console::Color meloncolor, const char* name, const char* version);
+
+	// Shorthand way to log to console and write to file with linebreak afterwards
+	static void LogToConsoleAndFile(Log log);
+
+	// Creates a log, and prints it to the console and file, all in one function.
+	static void QuickLog(const char* txt, LogType logType = Msg)
+	{LogToConsoleAndFile(Log(logType, nullptr, txt));}
+	
+	static void Internal_Msg(Console::Color meloncolor, Console::Color txtcolor, const char* namesection, const char* txt);
+	static void Internal_Warning(const char* namesection, const char* txt);
+	static void Internal_Error(const char* namesection, const char* txt);
+
+	class FileStream
+	{
+	public:
+		std::ofstream coss;
+		std::ofstream latest;
+		template <class T>
+		FileStream& operator<< (T val) { if (coss.is_open()) coss << val; if (latest.is_open()) latest << val; return *this; }
+		FileStream& operator<< (std::ostream& (*pfun)(std::ostream&)) { if (coss.is_open()) pfun(coss); if (latest.is_open()) pfun(latest); return *this; }
+		void Flush() { if (coss.is_open()) coss.flush(); if (latest.is_open()) latest.flush(); }
+	};
+	static FileStream LogFile;
+	static void Flush() { LogFile.Flush(); }
+
+	static const char* LatestLogFileName;
+	static const char* FileExtension;
+	
+private:
+	static const char* FilePrefix;
+	static void CleanOldLogs(const char* path);
+	static bool CompareWritetime(const std::filesystem::directory_entry& first, const std::filesystem::directory_entry& second) { return first.last_write_time().time_since_epoch() >= second.last_write_time().time_since_epoch(); }
+};

--- a/MelonLoader/Utils/MelonLogger.cs
+++ b/MelonLoader/Utils/MelonLogger.cs
@@ -27,18 +27,24 @@ namespace MelonLoader
 
         private static void NativeMsg(ConsoleColor namesection_color, ConsoleColor txt_color, string namesection, string txt)
         {
+            namesection ??= MelonUtils.GetMelonFromStackTrace()?.Info?.Name?.Replace(" ", "_");
+            
             Internal_Msg(namesection_color, txt_color, namesection, txt ?? "null");
             RunMsgCallbacks(namesection_color, txt_color, namesection, txt ?? "null");
         }
 
         private static void NativeWarning(string namesection, string txt)
         {
+            namesection ??= MelonUtils.GetMelonFromStackTrace()?.Info?.Name?.Replace(" ", "_");
+            
             Internal_Warning(namesection, txt ?? "null");
             RunWarningCallbacks(namesection, txt ?? "null");
         }
 
         private static void NativeError(string namesection, string txt)
         {
+            namesection ??= MelonUtils.GetMelonFromStackTrace()?.Info?.Name?.Replace(" ", "_");
+            
             Internal_Error(namesection, txt ?? "null");
             RunErrorCallbacks(namesection, txt ?? "null");
         }


### PR DESCRIPTION
Separated "Log" and "Logger" classes to their own files to keep things organised. Implemented a logging mutex to prevent two logs being processed at the same time. Fixed issue where melon name wouldn't be included in the log