### PR TITLE
Add null check on MonoEnumeratorWrapper

### DIFF
--- a/SM_Il2Cpp/MonoEnumeratorWrapper.cs
+++ b/SM_Il2Cpp/MonoEnumeratorWrapper.cs
@@ -16,7 +16,7 @@ namespace MelonLoader.Support
         public MonoEnumeratorWrapper(IEnumerator _enumerator) : base(ClassInjector.DerivedConstructorPointer<MonoEnumeratorWrapper>())
         {
             ClassInjector.DerivedConstructorBody(this);
-            enumerator = _enumerator;
+            enumerator = _enumerator ?? throw new NullReferenceException("routine is null");;
         }
 
         public Il2CppSystem.Object /*IEnumerator.*/Current


### PR DESCRIPTION
This matches the error Unity would give you.

https://github.com/Unity-Technologies/UnityCsReference/blob/e740821767d2290238ea7954457333f06e952bad/Runtime/Export/Scripting/MonoBehaviour.bindings.cs#L87-L88