### PR TITLE
Load Libraries From Mods Folder without Erroring

### DIFF
--- a/MelonLoader/Melons/MelonHandler.cs
+++ b/MelonLoader/Melons/MelonHandler.cs
@@ -157,7 +157,7 @@ namespace MelonLoader
             MelonCompatibilityLayer.Resolver resolver = MelonCompatibilityLayer.GetResolverFromAssembly(asm, filepath);
             if (resolver == null)
             {
-                MelonLogger.Error($"Failed to Load Assembly for {filepath}: No Compatibility Layer Found!");
+                MelonLogger.Msg($"Loaded library assembly at: {filepath}");
                 return;
             }
 

--- a/MelonLoader/Melons/MelonHandler.cs
+++ b/MelonLoader/Melons/MelonHandler.cs
@@ -157,7 +157,7 @@ namespace MelonLoader
             MelonCompatibilityLayer.Resolver resolver = MelonCompatibilityLayer.GetResolverFromAssembly(asm, filepath);
             if (resolver == null)
             {
-                MelonLogger.Msg($"Loaded library assembly at: {filepath}");
+                MelonLogger.Warning($"No Compatibility Layer for {filepath}");
                 return;
             }
 


### PR DESCRIPTION
I think this should be done because:
* Having library dll files in a separate folder is very unintuitive for users, especially since there's no easy way to distinguish the files. 
* The previous error message is also deceptive in that the assembly has actually already been loaded even though it doesn't have a "melon" inside. 
* Separate folders make it more difficult to update mods and dependencies with an API updater.