### PR TITLE
Fix unity tls interface crash due to invalid interface pointer

### DIFF
--- a/Dependencies/CompatibilityLayers/Il2CppUnityTls/Module.cs
+++ b/Dependencies/CompatibilityLayers/Il2CppUnityTls/Module.cs
@@ -171,6 +171,9 @@ namespace MelonLoader.CompatibilityLayers
             => UnityTlsInterface;
         private static void SetUnityTlsInterface(IntPtr ptr)
         {
+            if(UnityTlsInterface != IntPtr.Zero)
+                return;
+            
             UnityTlsInterface = ptr;
             OriginalSetUnityTlsInterface(ptr);
             Environment.SetEnvironmentVariable("MONO_TLS_PROVIDER", "unitytls");


### PR DESCRIPTION
Makes SetUnityTlsInterface only accept the first TLS interface it is passed, which helps if the function is empty and so shared with a bunch of other exported empty functions which are called a lot with random data (as was the case on Until You Fall).

As the TLS fixer immediately calls Il2CppInstallUnityTlsInterface after hooking it, it's pretty much guaranteed that the first thing the hook is called with is the result of that function, which means we're safe to accept the first result.