### PR TITLE
Assembly Generator: Implement Cpp2IL rewrite

### DIFF
--- a/Dependencies/Il2CppAssemblyGenerator/Packages/Cpp2IL.cs
+++ b/Dependencies/Il2CppAssemblyGenerator/Packages/Cpp2IL.cs
@@ -13,7 +13,7 @@ namespace MelonLoader.Il2CppAssemblyGenerator.Packages
                 Version = RemoteAPI.Info.ForceDumperVersion;
 #endif
             if (string.IsNullOrEmpty(Version) || Version.Equals("0.0.0.0"))
-                Version = "2022.0.0";
+                Version = "2022.1.0-pre-release.3";
 
             Name = nameof(Cpp2IL);
             Destination = Path.Combine(Core.BasePath, Name);
@@ -40,9 +40,10 @@ namespace MelonLoader.Il2CppAssemblyGenerator.Packages
                 "\"" + Path.GetDirectoryName(Core.GameAssemblyPath) + "\"",
                 "--exe-name",
                 "\"" + System.Diagnostics.Process.GetCurrentProcess().ProcessName + "\"",
-                "--skip-analysis",
-                "--skip-metadata-txts",
-                "--disable-registration-prompts"
+                "--use-processor",
+                "attributeinjector",
+                "--output-as",
+                "dummydll"
             }, false, new Dictionary<string, string>() {
                 {"NO_COLOR", "1"}
             }))


### PR DESCRIPTION
Implements the necessary command line argument changes to use the rewrite of Cpp2IL and bumps default version to `2022.1.0-pre-release.3`. 

Needs some way of ignoring remote api if it returns a version < 2022.1.0 because those versions will not work with the new command line arguments.

PR is here early though, so that CI picks it up, and people can get testing (use the debug build so it doesn't break)

Nightly link for this build: https://nightly.link/LavaGang/MelonLoader/actions/runs/2009739142