### PR TITLE
Fix niche case where alphabetical dll ordering was relevant

### DIFF
--- a/MelonLoader/Melons/MelonHandler.cs
+++ b/MelonLoader/Melons/MelonHandler.cs
@@ -1,12 +1,20 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 
 namespace MelonLoader
 {
     public static class MelonHandler
     {
+        /// <summary>
+        /// A couple common naming conventions for mods that may care about their assemblies definitely being loaded first,
+        /// even before the dependency graph can be made. This will almost never matter, but in a few niche
+        /// cases could prevent modders from needing to care about alphabetical ordering when naming their DLLs.
+        /// </summary>
+        private static readonly string[] PriorityLoadTerms = { "API", "Helper", "Lib"};
+        
         /// <summary>
         /// Directory of Plugins.
         /// </summary>
@@ -39,7 +47,9 @@ namespace MelonLoader
             MelonLogger.Msg(ConsoleColor.Yellow, line);
             MelonLogger.WriteSpacer();
 
-            var files = Directory.GetFiles(path, "*.dll");
+            var files = Directory.GetFiles(path, "*.dll")
+                .OrderByDescending(s => PriorityLoadTerms.Any(term => Path.GetFileName(s).Contains(term)))
+                .ThenBy(s => s);
             var melons = new List<T>();
 
             foreach (var f in files)


### PR DESCRIPTION
This is a bit of an arbitrary fix to a very niche issue, but it's benign enough that I think it's worth including.

Long story short: Having a dependency mod that has a different .dll name than internal Assembly Name will cause any directly dependent mods that come alphabetically before it to fail to load, crashing MelonLoader.

An example error of what happens without this change is below. AutoEscape comes alphabetically before but is dependent on an assembly named BloonsTD6 Mod Helper, but here that's been renamed to BtdModHelper.dll
```
Loading Melon Assembly: 'C:\Program Files (x86)\Steam\steamapps\common\BloonsTD6\Mods\AutoEscape.dll'...
[ERROR] System.TypeLoadException: Could not load type AutoEscape.AutoEscapeMod while decoding custom attribute: (null)
  at (wrapper managed-to-native) System.MonoCustomAttrs.GetCustomAttributesInternal(System.Reflection.ICustomAttributeProvider,System.Type,bool)
  at System.MonoCustomAttrs.GetCustomAttributesBase (System.Reflection.ICustomAttributeProvider obj, System.Type attributeType, System.Boolean inheritedOnly) [0x00013] in <e1319b7195c343e79b385cd3aa43f5dc>:0 
  at System.MonoCustomAttrs.GetCustomAttributes (System.Reflection.ICustomAttributeProvider obj, System.Type attributeType, System.Boolean inherit) [0x00037] in <e1319b7195c343e79b385cd3aa43f5dc>:0 
  at System.Reflection.Assembly.GetCustomAttributes (System.Type attributeType, System.Boolean inherit) [0x00000] in <e1319b7195c343e79b385cd3aa43f5dc>:0 
  at System.Attribute.GetCustomAttributes (System.Reflection.Assembly element, System.Boolean inherit) [0x00014] in <e1319b7195c343e79b385cd3aa43f5dc>:0 
  at MelonLoader.MelonUtils.PullAttributesFromAssembly[T] (System.Reflection.Assembly asm, System.Boolean inherit) [0x00000] in <e0709781047e4b5bb34a1650ae2b1be2>:0 
  at MelonLoader.MelonUtils.PullAttributeFromAssembly[T] (System.Reflection.Assembly asm, System.Boolean inherit) [0x00000] in <e0709781047e4b5bb34a1650ae2b1be2>:0 
  at MelonLoader.MelonAssembly.LoadMelons () [0x0008d] in <e0709781047e4b5bb34a1650ae2b1be2>:0 
  at MelonLoader.MelonAssembly.LoadMelonAssembly (System.Reflection.Assembly assembly) [0x00083] in <e0709781047e4b5bb34a1650ae2b1be2>:0 
  at MelonLoader.MelonAssembly.LoadMelonAssembly (System.String path) [0x00036] in <e0709781047e4b5bb34a1650ae2b1be2>:0 
  at MelonLoader.MelonHandler.LoadMelonsFromDirectory[T] (System.String path) [0x0007d] in <e0709781047e4b5bb34a1650ae2b1be2>:0 
  at MelonLoader.Core.Start () [0x00014] in <e0709781047e4b5bb34a1650ae2b1be2>:0 
```

I've tried *a lot* of different workarounds, but it's hard to avoid when the error itself is coming from the actual .NET system code.

This is a pretty non-galaxy-brain fix here, just making a quick guess on if the mod might need its Assembly loaded first based on if it contains some common terms like "API", "Lib" or "Helper". This should not cause any breakage at all, but would help to avoid having to tell users to put _ and ~ characters at the beginnings of certain DLL names.

You can ping me @doombubbles in the #modders-chat of the MelonLoader discord if you've got questions / concerns / a better solution.