### PR TITLE
use dumb events to avoid garbage allocations

### DIFF
--- a/MelonLoader/MelonEvents.cs
+++ b/MelonLoader/MelonEvents.cs
@@ -41,22 +41,22 @@ namespace MelonLoader
         /// <summary>
         /// Called once per frame.
         /// </summary>
-        public readonly static MelonEvent OnUpdate = new MelonEvent();
+        public readonly static VeryStupidEvent OnUpdate = new VeryStupidEvent();
 
         /// <summary>
         /// Called every 0.02 seconds, unless Time.fixedDeltaTime has a different Value. It is recommended to do all important Physics calculations inside this Callback.
         /// </summary>
-        public readonly static MelonEvent OnFixedUpdate = new MelonEvent();
+        public readonly static VeryStupidEvent OnFixedUpdate = new VeryStupidEvent();
 
         /// <summary>
         /// Called once per frame, after <see cref="OnUpdate"/>.
         /// </summary>
-        public readonly static MelonEvent OnLateUpdate = new MelonEvent();
+        public readonly static VeryStupidEvent OnLateUpdate = new VeryStupidEvent();
 
         /// <summary>
         /// Called at every IMGUI event. Only use this for drawing IMGUI Elements.
         /// </summary>
-        public readonly static MelonEvent OnGUI = new MelonEvent();
+        public readonly static VeryStupidEvent OnGUI = new VeryStupidEvent();
 
         /// <summary>
         /// Called when a new Scene is loaded.

--- a/MelonLoader/Melons/Events/MelonEvent.cs
+++ b/MelonLoader/Melons/Events/MelonEvent.cs
@@ -115,6 +115,33 @@ namespace MelonLoader
         }
     }
 
+    public class VeryStupidEvent
+    {
+        private struct VSEInternal
+        {
+            public Action del;
+            public int priority;
+        }
+        private List<VSEInternal> activeEvents = new();
+        public void Subscribe(Action del, int priority)
+        {
+            var index = activeEvents.FindIndex(x => x.priority < priority);
+            if (index == -1) index = activeEvents.Count;
+            activeEvents.Insert(index, new VSEInternal { del = del, priority = priority });
+        }
+        public void Invoke()
+        {
+            foreach (var vse in activeEvents)
+            {
+                try { vse.del(); }
+                catch (Exception ex)
+                {
+                    MelonLogger.Error(ex.ToString());
+                }
+            }
+        }
+    }
+
     #region Param Children
     public class MelonEvent : MelonEventBase<LemonAction>
     {


### PR DESCRIPTION
This replaces MelonEvent for unconditionally ran events with very dumb versions that don't allocate any memory.
Previously on 0.5.4, Melonloader would allocate ~2.5KiB per frame in 31 allocations with 13 mods without any called functions.
On alpha-dev, it was ~3.1KiB in 84 allocations.

The name should be changed. I'm open to suggestions.

@SlidyDev
Since I butchered your work I'd like for you to sanity check if I broke anything important.

![image](https://user-images.githubusercontent.com/22580720/185008129-0d929d1a-20bb-4feb-8e49-ea62061db285.png)
