### PR TITLE
Add Generic Return type <T> on one Method Override for CreateEntry<T>() in MelonPreferences_Category

### DIFF
--- a/MelonLoader/Preferences/MelonPreferences_Category.cs
+++ b/MelonLoader/Preferences/MelonPreferences_Category.cs
@@ -22,7 +22,7 @@ namespace MelonLoader
             MelonPreferences.Categories.Add(this);
         }
 
-        public MelonPreferences_Entry CreateEntry<T>(string identifier, T default_value, string display_name, bool is_hidden) 
+        public MelonPreferences_Entry<T> CreateEntry<T>(string identifier, T default_value, string display_name, bool is_hidden) 
             => CreateEntry(identifier, default_value, display_name, null, is_hidden, false, null, null);
         public MelonPreferences_Entry<T> CreateEntry<T>(string identifier, T default_value, string display_name,
             string description, bool is_hidden, bool dont_save_default, Preferences.ValueValidator validator)


### PR DESCRIPTION
Maybe there is a reason for this, but I can't see it, so I thought I would make it the same as the other Methods.
![image](https://user-images.githubusercontent.com/31988415/186892387-fdb8be05-dd38-4ce3-bb1b-faaeadee58e5.png)

Makes things like this nicer (negates need for typecast):
![image](https://user-images.githubusercontent.com/31988415/186892543-14d059b3-788d-44ee-a035-3f16e9e94e1d.png)
