### PR TITLE
Il2cpp assemblies folder

### DIFF
--- a/Dependencies/Il2CppAssemblyGenerator/Core.cs
+++ b/Dependencies/Il2CppAssemblyGenerator/Core.cs
@@ -135,7 +135,7 @@ namespace MelonLoader.Il2CppAssemblyGenerator
             for (int i = 0; i < Config.Values.OldFiles.Count; i++)
             {
                 string filename = Config.Values.OldFiles[i];
-                string filepath = Path.Combine(ManagedPath, filename);
+                string filepath = Path.Combine(MelonEnvironment.Il2CppAssembliesDirectory, filename);
                 if (File.Exists(filepath))
                 {
                     Logger.Msg("Deleting " + filename);
@@ -148,15 +148,17 @@ namespace MelonLoader.Il2CppAssemblyGenerator
         private static void OldFiles_LAM()
         {
             string[] filepathtbl = Directory.GetFiles(il2cppinterop.OutputFolder);
-            for (int i = 0; i < filepathtbl.Length; i++)
+			string il2CppAssembliesDirectory = MelonEnvironment.Il2CppAssembliesDirectory;
+			for (int i = 0; i < filepathtbl.Length; i++)
             {
                 string filepath = filepathtbl[i];
                 string filename = Path.GetFileName(filepath);
                 Logger.Msg("Moving " + filename);
                 Config.Values.OldFiles.Add(filename);
-                string newfilepath = Path.Combine(ManagedPath, filename);
+				string newfilepath = Path.Combine(il2CppAssembliesDirectory, filename);
                 if (File.Exists(newfilepath))
                     File.Delete(newfilepath);
+                Directory.CreateDirectory(il2CppAssembliesDirectory);
                 File.Move(filepath, newfilepath);
             }
             Config.Save();

--- a/Dependencies/Il2CppAssemblyGenerator/Core.cs
+++ b/Dependencies/Il2CppAssemblyGenerator/Core.cs
@@ -148,14 +148,14 @@ namespace MelonLoader.Il2CppAssemblyGenerator
         private static void OldFiles_LAM()
         {
             string[] filepathtbl = Directory.GetFiles(il2cppinterop.OutputFolder);
-			string il2CppAssembliesDirectory = MelonEnvironment.Il2CppAssembliesDirectory;
-			for (int i = 0; i < filepathtbl.Length; i++)
+            string il2CppAssembliesDirectory = MelonEnvironment.Il2CppAssembliesDirectory;
+            for (int i = 0; i < filepathtbl.Length; i++)
             {
                 string filepath = filepathtbl[i];
                 string filename = Path.GetFileName(filepath);
                 Logger.Msg("Moving " + filename);
                 Config.Values.OldFiles.Add(filename);
-				string newfilepath = Path.Combine(il2CppAssembliesDirectory, filename);
+                string newfilepath = Path.Combine(il2CppAssembliesDirectory, filename);
                 if (File.Exists(newfilepath))
                     File.Delete(newfilepath);
                 Directory.CreateDirectory(il2CppAssembliesDirectory);

--- a/Dependencies/Il2CppAssemblyGenerator/Packages/Il2CppInterop.cs
+++ b/Dependencies/Il2CppAssemblyGenerator/Packages/Il2CppInterop.cs
@@ -26,7 +26,7 @@ namespace MelonLoader.Il2CppAssemblyGenerator.Packages
             Name = nameof(Il2CppAssemblyUnhollower);
             URL = $"https://github.com/SamboyCoding/{Name}/releases/download/v{Version}/{Name}.{Version}.zip";
             Destination = Path.Combine(Core.BasePath, Name);
-            OutputFolder = Path.Combine(Destination, "Managed");
+            OutputFolder = Path.Combine(Destination, "Il2CppAssemblies");
         }
 
         internal override bool ShouldSetup()

--- a/MelonLoader/Fixes/DotnetLoadFromManagedFolderFix.cs
+++ b/MelonLoader/Fixes/DotnetLoadFromManagedFolderFix.cs
@@ -44,13 +44,15 @@ namespace MelonLoader.Fixes
             var filename = name.Name + ".dll";
 
             var osSpecificPath = Path.Combine(OurRuntimeDir, filename);
-            var managedPath = Path.Combine(MelonEnvironment.MelonManagedDirectory, filename);
-            var modsPath = Path.Combine(MelonEnvironment.ModsDirectory, filename);
+            var il2cppPath = Path.Combine(MelonEnvironment.Il2CppAssembliesDirectory, filename);
+			var managedPath = Path.Combine(MelonEnvironment.MelonManagedDirectory, filename);
+			var modsPath = Path.Combine(MelonEnvironment.ModsDirectory, filename);
             var userlibsPath = Path.Combine(MelonEnvironment.UserLibsDirectory, filename);
             var gameRootPath = Path.Combine(MelonEnvironment.GameRootDirectory, filename);
 
             var ret = TryLoad(alc, osSpecificPath)
-                ?? TryLoad(alc, managedPath)
+				?? TryLoad(alc, il2cppPath)
+				?? TryLoad(alc, managedPath)
                 ?? TryLoad(alc, modsPath)
                 ?? TryLoad(alc, userlibsPath)
                 ?? TryLoad(alc, gameRootPath);

--- a/MelonLoader/Fixes/DotnetLoadFromManagedFolderFix.cs
+++ b/MelonLoader/Fixes/DotnetLoadFromManagedFolderFix.cs
@@ -45,14 +45,14 @@ namespace MelonLoader.Fixes
 
             var osSpecificPath = Path.Combine(OurRuntimeDir, filename);
             var il2cppPath = Path.Combine(MelonEnvironment.Il2CppAssembliesDirectory, filename);
-			var managedPath = Path.Combine(MelonEnvironment.MelonManagedDirectory, filename);
-			var modsPath = Path.Combine(MelonEnvironment.ModsDirectory, filename);
+            var managedPath = Path.Combine(MelonEnvironment.MelonManagedDirectory, filename);
+            var modsPath = Path.Combine(MelonEnvironment.ModsDirectory, filename);
             var userlibsPath = Path.Combine(MelonEnvironment.UserLibsDirectory, filename);
             var gameRootPath = Path.Combine(MelonEnvironment.GameRootDirectory, filename);
 
             var ret = TryLoad(alc, osSpecificPath)
-				?? TryLoad(alc, il2cppPath)
-				?? TryLoad(alc, managedPath)
+                ?? TryLoad(alc, il2cppPath)
+                ?? TryLoad(alc, managedPath)
                 ?? TryLoad(alc, modsPath)
                 ?? TryLoad(alc, userlibsPath)
                 ?? TryLoad(alc, gameRootPath);

--- a/MelonLoader/Utils/MelonEnvironment.cs
+++ b/MelonLoader/Utils/MelonEnvironment.cs
@@ -44,8 +44,9 @@ namespace MelonLoader.Utils
         public static string UnityPlayerPath => Path.Combine(GameRootDirectory, "UnityPlayer.dll");
 
         public static string MelonManagedDirectory => Path.Combine(MelonLoaderDirectory, "Managed");
+		public static string Il2CppAssembliesDirectory => Path.Combine(MelonLoaderDirectory, "Il2CppAssemblies");
 
-        internal static void PrintEnvironment()
+		internal static void PrintEnvironment()
         {
             //These must not be changed, lum needs them
             MelonLogger.MsgDirect($"Core::BasePath = {MelonBaseDirectory}");

--- a/MelonLoader/Utils/MelonEnvironment.cs
+++ b/MelonLoader/Utils/MelonEnvironment.cs
@@ -44,9 +44,9 @@ namespace MelonLoader.Utils
         public static string UnityPlayerPath => Path.Combine(GameRootDirectory, "UnityPlayer.dll");
 
         public static string MelonManagedDirectory => Path.Combine(MelonLoaderDirectory, "Managed");
-		public static string Il2CppAssembliesDirectory => Path.Combine(MelonLoaderDirectory, "Il2CppAssemblies");
+        public static string Il2CppAssembliesDirectory => Path.Combine(MelonLoaderDirectory, "Il2CppAssemblies");
 
-		internal static void PrintEnvironment()
+        internal static void PrintEnvironment()
         {
             //These must not be changed, lum needs them
             MelonLogger.MsgDirect($"Core::BasePath = {MelonBaseDirectory}");


### PR DESCRIPTION
This pull request moves the generated Il2Cpp assemblies into a separate folder. This has been tested for correct assembly resolution on The Long Dark.