### PR TITLE
allow overriding the deobfuscator remote API URL

### DIFF
--- a/Dependencies/Il2CppAssemblyGenerator/Config.cs
+++ b/Dependencies/Il2CppAssemblyGenerator/Config.cs
@@ -28,6 +28,7 @@ namespace MelonLoader.Il2CppAssemblyGenerator
 
         public class AssemblyGeneratorConfiguration
         {
+            public string RemoteAPIOverride = null;
             public string GameAssemblyHash = null;
             public string DeobfuscationRegex = null;
             public string UnityVersion = "0.0.0.0";


### PR DESCRIPTION
Didn't actually test this yet since MelonLoader still doesn't crosscompile :)
I'll wait for the actions result.

The diff is fairly big but little was changed. Moved the loop content into a separate function with different indentation.