### PR TITLE
NativeHook<T>: Data race allowed on T 

### DIFF
--- a/Bootstrap/src/hooks/mod.rs
+++ b/Bootstrap/src/hooks/mod.rs
@@ -52,8 +52,8 @@ impl<T> NativeHook<T> {
     }
 }
 
-unsafe impl<T> Send for NativeHook<T> {}
-unsafe impl<T> Sync for NativeHook<T> {}
+unsafe impl<T: Send> Send for NativeHook<T> {}
+unsafe impl<T: Sync> Sync for NativeHook<T> {}
 
 impl<T> Clone for NativeHook<T> {
     fn clone(&self) -> Self {


### PR DESCRIPTION
Hi,
I found a memory-safety/soundness issue in this crate while scanning Rust code for potential vulnerabilities. This PR contains a fix for the issue.

# Issue Description
`NativeHook<T>` unconditionally implements Sync. This allows users to create data races on `T: !Sync`. Such data races can lead to undefined behavior.
https://github.com/LavaGang/MelonLoader/blob/41071711aa1b20d340196000b51f862118c736be/Bootstrap/src/hooks/mod.rs#L55-L56