### PR TITLE
don't abort game launch on MelonLoader initialization failure

### DIFF
--- a/Bootstrap/src/core.rs
+++ b/Bootstrap/src/core.rs
@@ -5,7 +5,7 @@ use crate::{console, errors::DynErr, hooks, internal_failure, logging::logger};
 #[ctor]
 fn startup() {
     init().unwrap_or_else(|e| {
-        internal_failure!("Failed to initialize MelonLoader: {}", e.to_string());
+        eprintln!("Failed to initialize MelonLoader: {}", e.to_string());
     })
 }
 

--- a/MelonProxy/src/lib.rs
+++ b/MelonProxy/src/lib.rs
@@ -94,7 +94,7 @@ pub unsafe extern "stdcall" fn DllMain(module: HMODULE, reason: isize, _res: *co
         init(std::ptr::null_mut());
 
         core::init().unwrap_or_else(|e| {
-            internal_failure!("Failed to initialize MelonLoader: {}", e)
+            eprintln!("Failed to initialize MelonLoader: {}", e)
         });
     }
 
@@ -105,7 +105,7 @@ pub unsafe extern "stdcall" fn DllMain(module: HMODULE, reason: isize, _res: *co
 #[ctor::ctor]
 fn init() {
     core::init().unwrap_or_else(|e| {
-        internal_failure!("Failed to initialize MelonLoader: {}", e)
+        eprintln!("Failed to initialize MelonLoader: {}", e)
     });
 }
 


### PR DESCRIPTION
See #618 

Launching a game with a custom launcher that isn't using unity but also loads the proxy dll like https://store.steampowered.com/app/868550/What_do_you_hear_Yanny_vs_Laurel/ will abort the launch process. If you still want it to abort on other issues than NotUnity, I could alter the PR for that condition. The current handling probably breaks more games.