### PR TITLE
Fix debugger.

### DIFF
--- a/MelonLoader/Core.cs
+++ b/MelonLoader/Core.cs
@@ -41,7 +41,7 @@ namespace MelonLoader
 #if NET6_0
             if (MelonLaunchOptions.Core.UserWantsDebugger && MelonEnvironment.IsDotnetRuntime)
             {
-                MelonLogger.Msg("[Init] User requested debugger, attempting to launch now...");
+                Console.WriteLine("[Init] User requested debugger, attempting to launch now...");
                 Debugger.Launch();
             }
 


### PR DESCRIPTION
Changed MelonLogger.Msg to Console.WriteLine when logging about launching the debugger.

Fixes https://github.com/LavaGang/MelonLoader/issues/719 (I had no idea it would be this easy until two seconds ago)