### PR TITLE
Add External Command Line Arguments

### DIFF
--- a/MelonLoader/MelonLaunchOptions.cs
+++ b/MelonLoader/MelonLaunchOptions.cs
@@ -61,23 +61,23 @@ namespace MelonLoader
                 {
                     if (!argEnumerator.MoveNext())
                     {
-                        ExternalArguments.Add(fullcmd, null);
+                        ExternalArguments.Add(cmd, null);
                         continue;
                     }
 
                     string cmdArg = argEnumerator.Current;
                     if (string.IsNullOrEmpty(cmdArg))
                     {
-                        ExternalArguments.Add(fullcmd, null);
+                        ExternalArguments.Add(cmd, null);
                         continue;
                     }
 
                     if (cmdArg.StartsWith("--"))
                     {
-                        ExternalArguments.Add(fullcmd, null);
+                        ExternalArguments.Add(cmd, null);
                         continue;
                     }
-                    ExternalArguments.Add(fullcmd, cmdArg);
+                    ExternalArguments.Add(cmd, cmdArg);
                 }
             }
         }

--- a/MelonLoader/MelonLaunchOptions.cs
+++ b/MelonLoader/MelonLaunchOptions.cs
@@ -9,6 +9,12 @@ namespace MelonLoader
         private static Dictionary<string, Action> WithoutArg = new Dictionary<string, Action>();
         private static Dictionary<string, Action<string>> WithArg = new Dictionary<string, Action<string>>();
 
+         /// <summary>
+         /// Dictionary of all Arguments with value (if found) that were not used by MelonLoader
+         /// <para>
+         /// <b>Key</b> is the argument, <b>Value</b> is the value for the argument, <c>null</c> if not found
+         /// </para>
+         /// </summary>
         public static Dictionary<string, string> ExternalArguments { get; private set; } = new Dictionary<string, string>();
 
         static MelonLaunchOptions()

--- a/MelonLoader/MelonLaunchOptions.cs
+++ b/MelonLoader/MelonLaunchOptions.cs
@@ -10,7 +10,7 @@ namespace MelonLoader
         private static Dictionary<string, Action<string>> WithArg = new Dictionary<string, Action<string>>();
 
         /// <summary>
-        /// List of command line arguments (with arguments if provided) that are not used by MelonLoader
+        /// List of command line arguments (with values if provided) that are not used by MelonLoader
         /// </summary>
         public static Dictionary<string, string> ExternalArguments { get; private set; } = new Dictionary<string, string>();
 

--- a/MelonLoader/MelonLaunchOptions.cs
+++ b/MelonLoader/MelonLaunchOptions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace MelonLoader
 {
@@ -7,6 +8,11 @@ namespace MelonLoader
     {
         private static Dictionary<string, Action> WithoutArg = new Dictionary<string, Action>();
         private static Dictionary<string, Action<string>> WithArg = new Dictionary<string, Action<string>>();
+
+        /// <summary>
+        /// List of command line arguments (with arguments if provided) that are not used by MelonLoader
+        /// </summary>
+        public static Dictionary<string, string> ExternalArguments { get; private set; } = new Dictionary<string, string>();
 
         static MelonLaunchOptions()
         {
@@ -51,6 +57,28 @@ namespace MelonLoader
                     foundOptions.Add($"{fullcmd} = {cmdArg}");
                     withArgFunc(cmdArg);
                 }
+                if (foundOptions.Where(x => x.StartsWith(fullcmd)).Count() <= 0)
+                {
+                    if (!argEnumerator.MoveNext())
+                    {
+                        ExternalArguments.Add(fullcmd, null);
+                        continue;
+                    }
+
+                    string cmdArg = argEnumerator.Current;
+                    if (string.IsNullOrEmpty(cmdArg))
+                    {
+                        ExternalArguments.Add(fullcmd, null);
+                        continue;
+                    }
+
+                    if (cmdArg.StartsWith("--"))
+                    {
+                        ExternalArguments.Add(fullcmd, null);
+                        continue;
+                    }
+                    ExternalArguments.Add(fullcmd, cmdArg);
+                }
             }
         }
 
@@ -64,6 +92,7 @@ namespace MelonLoader
                 DEV,
                 BOTH
             }
+
             public static LoadModeEnum LoadMode_Plugins { get; internal set; }
             public static LoadModeEnum LoadMode_Mods { get; internal set; }
             public static bool QuitFix { get; internal set; }
@@ -102,6 +131,7 @@ namespace MelonLoader
                 RANDOMRAINBOW,
                 LEMON
             };
+
             public static DisplayMode Mode { get; internal set; }
             public static bool CleanUnityLogs { get; internal set; } = true;
             public static bool ShouldSetTitle { get; internal set; } = true;
@@ -167,6 +197,6 @@ namespace MelonLoader
             }
         }
 
-        #endregion
+        #endregion Args
     }
 }

--- a/MelonLoader/MelonLaunchOptions.cs
+++ b/MelonLoader/MelonLaunchOptions.cs
@@ -9,9 +9,6 @@ namespace MelonLoader
         private static Dictionary<string, Action> WithoutArg = new Dictionary<string, Action>();
         private static Dictionary<string, Action<string>> WithArg = new Dictionary<string, Action<string>>();
 
-        /// <summary>
-        /// List of command line arguments (with values if provided) that are not used by MelonLoader
-        /// </summary>
         public static Dictionary<string, string> ExternalArguments { get; private set; } = new Dictionary<string, string>();
 
         static MelonLaunchOptions()


### PR DESCRIPTION
Adds a new Dictionary variable in `MelonLaunchOptions.cs` called `ExternalArguments` which contains a list of names & values (if found) of command line arguments that are not used by MelonLoader. This can be useful for mods and/or plugins to have the option to use command line arguments. I have tested the changes and it doesn't seem to have any issues. It's not something that will be often used by developers, but I think it would be a great little addition.