### PR TITLE
Update the Unity Dependencies source repository URL

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,9 @@
 name: Build MelonLoader
-run-name: ${{ vars.DEVVERSION }}${{ github.event_name != 'workflow_dispatch' && format('-ci.{0}', github.run_number) || '' }} | ${{ github.event_name != 'workflow_dispatch' && (github.event.head_commit.message || format('`[PR]` {0}', github.event.pull_request.title)) || 'Manual Build' }}
+
+run-name: 0.6.7${{ github.event_name != 'workflow_dispatch' && format('-ci.{0}', github.run_number) || '' }} | ${{ github.event_name != 'workflow_dispatch' && (github.event.head_commit.message || format('`[PR]` {0}', github.event.pull_request.title)) || 'Manual Build' }}
+
+env:
+  DEVVERSION: "0.6.7"
 
 on:
   push:
@@ -23,7 +27,7 @@ jobs:
         run: dotnet restore
 
       - name: Build Melonloader Core Debug
-        run: dotnet build --no-restore -c Debug -p:Platform="Windows - x64" -p:Version="${{ vars.DEVVERSION }}${{ github.event_name != 'workflow_dispatch' && format('.{0}', github.run_number) || '' }}" # Platform is actually irrelevant for core, it's compiled as AnyCPU either way
+        run: dotnet build --no-restore -c Debug -p:Platform="Windows - x64" -p:Version="${{ env.DEVVERSION }}${{ github.event_name != 'workflow_dispatch' && format('.{0}', github.run_number) || '' }}" # Platform is actually irrelevant for core, it's compiled as AnyCPU either way
 
       - name: Upload Debug Core Artifact
         uses: actions/upload-artifact@v4
@@ -32,7 +36,7 @@ jobs:
           path: Output/Debug/MelonLoader/
 
       - name: Build MelonLoader Core Release
-        run: dotnet build --no-restore -c Release -p:Platform="Windows - x64" -p:Version="${{ vars.DEVVERSION }}${{ github.event_name != 'workflow_dispatch' && format('.{0}', github.run_number) || '' }}"
+        run: dotnet build --no-restore -c Release -p:Platform="Windows - x64" -p:Version="${{ env.DEVVERSION }}${{ github.event_name != 'workflow_dispatch' && format('.{0}', github.run_number) || '' }}"
 
       - name: Upload Release Core Artifact
         uses: actions/upload-artifact@v4
@@ -41,13 +45,13 @@ jobs:
           path: Output/Release/MelonLoader/
 
       - name: Pack NuGet Package
-        run: dotnet pack --no-build -c Release -p:Version="${{ vars.DEVVERSION }}${{ github.event_name != 'workflow_dispatch' && format('-ci.{0}', github.run_number) || '' }}"
+        run: dotnet pack --no-build -c Release -p:Version="${{ env.DEVVERSION }}${{ github.event_name != 'workflow_dispatch' && format('-ci.{0}', github.run_number) || '' }}"
 
       - name: Upload NuGet Artifact
         uses: actions/upload-artifact@v4
         with:
           name: MelonLoader.NuGet
-          path: Output/Release/MelonLoader/LavaGang.MelonLoader.${{ vars.DEVVERSION }}${{ github.event_name != 'workflow_dispatch' && format('-ci.{0}', github.run_number) || '' }}.nupkg
+          path: Output/Release/MelonLoader/LavaGang.MelonLoader.${{ env.DEVVERSION }}${{ github.event_name != 'workflow_dispatch' && format('-ci.{0}', github.run_number) || '' }}.nupkg
   build_rust_windows:
     name: Build Native Binaries (Windows)
     runs-on: windows-latest

--- a/Dependencies/Il2CppAssemblyGenerator/Packages/UnityDependencies.cs
+++ b/Dependencies/Il2CppAssemblyGenerator/Packages/UnityDependencies.cs
@@ -8,7 +8,7 @@ namespace MelonLoader.Il2CppAssemblyGenerator.Packages
         {
             Name = nameof(UnityDependencies);
             Version = InternalUtils.UnityInformationHandler.EngineVersion.ToStringWithoutType();
-            URL = $"https://github.com/LavaGang/Unity-Runtime-Libraries/raw/master/{Version}.zip";
+            URL = $"https://github.com/LavaGang/MelonLoader.UnityDependencies/releases/download/{Version}/Managed.zip";
             Destination = Path.Combine(Core.BasePath, Name);
             FilePath = Path.Combine(Core.BasePath, $"{Name}_{Version}.zip");
         }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <Version>0.6.6</Version>
+        <Version>0.6.7</Version>
 		<Authors>Lava Gang</Authors>
 		<Company>discord.gg/2Wn3N2P</Company>
 		<Copyright>Copyright (c) 2022 Lava Gang</Copyright>

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Third-party Libraries used as Source Code and/or bundled in Binary Form:
  
 External Libraries and Tools that are downloaded and used at Runtime:
 - [Cpp2IL](https://github.com/SamboyCoding/Cpp2IL) is licensed under the MIT License. See [LICENSE](https://github.com/SamboyCoding/Cpp2IL/blob/master/LICENSE) for the full License.
-- Unity Runtime Libraries from [Unity-Runtime-Libraries](https://github.com/LavaGang/Unity-Runtime-Libraries) are part of Unity Software.  
+- Unity Runtime Libraries from [MelonLoader.UnityDependencies](https://github.com/LavaGang/MelonLoader.UnityDependencies) are part of Unity Software.  
 Their usage is subject to [Unity Terms of Service](https://unity3d.com/legal/terms-of-service), including [Unity Software Additional Terms](https://unity3d.com/legal/terms-of-service/software).
 
 See [MelonLoader Wiki](https://melonwiki.xyz/#/credits) for the full Credits.


### PR DESCRIPTION
Updating to the new repository: https://github.com/LavaGang/MelonLoader.UnityDependencies

Also updated the workflow version to 0.6.7