### PR TITLE
Support unicode paths for Mono

### DIFF
--- a/MelonLoader.Bootstrap/RuntimeHandlers/Mono/MonoHandler.cs
+++ b/MelonLoader.Bootstrap/RuntimeHandlers/Mono/MonoHandler.cs
@@ -93,7 +93,7 @@ internal static class MonoHandler
                     foreach (var dll in Directory.EnumerateFiles(overridesDir, "*.dll"))
                     {
                         MelonDebug.Log("Loading assembly: " + dll);
-                        if (Mono.DomainAssemblyOpen(Domain, dll) == 0)
+                        if (Mono.TryLoadAssemblyUnicode(Domain, dll) == 0)
                             MelonDebug.Log("Assembly failed to load!");
                     }
                 }
@@ -101,7 +101,7 @@ internal static class MonoHandler
         }
 
         MelonDebug.Log("Loading ML assembly");
-        var assembly = Mono.DomainAssemblyOpen(Domain, mlPath);
+        var assembly = Mono.TryLoadAssemblyUnicode(Domain, mlPath);
         if (assembly == 0)
         {
             Core.Logger.Error($"Failed to load the Mono MelonLoader assembly");

--- a/MelonLoader.Bootstrap/RuntimeHandlers/Mono/MonoLib.cs
+++ b/MelonLoader.Bootstrap/RuntimeHandlers/Mono/MonoLib.cs
@@ -118,6 +118,20 @@ internal class MonoLib
         };
     }
 
+    public nint TryLoadAssemblyUnicode(nint domain, string path)
+    {
+        if (!File.Exists(path))
+            return 0;
+
+        var dir = Path.GetDirectoryName(path)!;
+        var prevCwd = Directory.GetCurrentDirectory();
+
+        Directory.SetCurrentDirectory(dir);
+        var asm = DomainAssemblyOpen(domain, Path.GetFileName(path));
+        Directory.SetCurrentDirectory(prevCwd);
+        return asm;
+    }
+
     private static string? FindMonoPath(string searchDir)
     {
         foreach (var folder in folderNames)


### PR DESCRIPTION
Since the Mono API only supports ASCII paths, we need to find workarounds for unicode.

Closes #246