### PR TITLE
Change console encoding to UTF8

### DIFF
--- a/MelonLoader.Bootstrap/Logging/ConsoleHandler.cs
+++ b/MelonLoader.Bootstrap/Logging/ConsoleHandler.cs
@@ -47,7 +47,7 @@ internal static partial class ConsoleHandler
         Console.SetError(new StreamWriter(Console.OpenStandardError()) { AutoFlush = true });
         Console.SetIn(new StreamReader(Console.OpenStandardInput()));
 
-        Console.OutputEncoding = Encoding.Unicode;
+        Console.OutputEncoding = Encoding.UTF8;
 
         outputHandle = GetStdHandle(StdOutputHandle);
 #endif


### PR DESCRIPTION
Unicode still breaks some Asian character. UTF8 seems to fix that.

Closes #739 