### PR TITLE
Prevent obsolete references from compiling

### DIFF
--- a/Dependencies/Il2CppAssemblyGenerator/Config.cs
+++ b/Dependencies/Il2CppAssemblyGenerator/Config.cs
@@ -35,7 +35,7 @@ namespace MelonLoader.Il2CppAssemblyGenerator
             public string DumperVersion = "0.0.0.0";
             public string DumperSCRSVersion = "0.0.0.0";
 
-            [Obsolete("Il2CppAssemblyUnhollower support was discontinued.", true)]
+            [Obsolete("Il2CppAssemblyUnhollower support was discontinued. This will be removed in a future update.", true)]
             public bool UseInterop = true;
 
             public List<string> OldFiles = new List<string>();

--- a/Dependencies/SupportModules/Il2Cpp/Main.cs
+++ b/Dependencies/SupportModules/Il2Cpp/Main.cs
@@ -11,10 +11,9 @@ using Il2CppInterop.Common;
 using Microsoft.Extensions.Logging;
 using MelonLoader.Utils;
 using System.IO;
+using MelonLoader.InternalUtils;
 
 [assembly: MelonLoader.PatchShield]
-
-#pragma warning disable CS0618 // Type or member is obsolete
 
 namespace MelonLoader.Support
 {
@@ -53,7 +52,7 @@ namespace MelonLoader.Support
             }).AddLogger(new InteropLogger())
               .AddHarmonySupport();
 
-            if (MelonLaunchOptions.Console.CleanUnityLogs)
+            if (!LoaderConfig.Current.UnityEngine.DisableConsoleLogCleaner)
                 ConsoleCleaner();
 
             SceneHandler.Init();
@@ -162,7 +161,7 @@ namespace MelonLoader.Support
                 
                 var addr = _detourFrom;
                 nint addrPtr = (nint)(&addr);
-                MelonUtils.NativeHookAttachDirect(addrPtr, _targetPtr);
+                BootstrapInterop.NativeHookAttachDirect(addrPtr, _targetPtr);
                 NativeStackWalk.RegisterHookAddr((ulong)addrPtr, $"Il2CppInterop detour of 0x{addrPtr:X} -> 0x{_targetPtr:X}");
 
                 _originalPtr = addr;
@@ -176,7 +175,7 @@ namespace MelonLoader.Support
                 var addr = _detourFrom;
                 nint addrPtr = (nint)(&addr);
 
-                MelonUtils.NativeHookDetach(addrPtr, _targetPtr);
+                BootstrapInterop.NativeHookDetach(addrPtr, _targetPtr);
                 NativeStackWalk.UnregisterHookAddr((ulong)addrPtr);
 
                 _targetPtr = IntPtr.Zero;

--- a/MelonLoader/Attributes/MelonAuthorColorAttribute.cs
+++ b/MelonLoader/Attributes/MelonAuthorColorAttribute.cs
@@ -10,7 +10,7 @@ namespace MelonLoader
         /// <summary>
         /// Color of the Author Log.
         /// </summary>
-        [Obsolete("Color is obsolete. Use DrawingColor for full Color support.")]
+        [Obsolete("Color is obsolete. Use DrawingColor for full Color support. This will be removed in a future update.", true)]
         public ConsoleColor Color
         {
             get => LoggerUtils.DrawingColorToConsoleColor(DrawingColor);
@@ -25,7 +25,7 @@ namespace MelonLoader
         public MelonAuthorColorAttribute() 
             => DrawingColor = MelonLogger.DefaultTextColor;
 
-        [Obsolete("ConsoleColor is obsolete, use the (int, int, int, int) constructor instead.")]
+        [Obsolete("ConsoleColor is obsolete, use the (int, int, int, int) constructor instead. This will be removed in a future update.", true)]
         public MelonAuthorColorAttribute(ConsoleColor color) 
             => Color = ((color == ConsoleColor.Black) ? LoggerUtils.DrawingColorToConsoleColor(MelonLogger.DefaultMelonColor) : color);
 

--- a/MelonLoader/Attributes/MelonColorAttribute.cs
+++ b/MelonLoader/Attributes/MelonColorAttribute.cs
@@ -10,7 +10,7 @@ namespace MelonLoader
         /// <summary>
         /// Color of the Melon.
         /// </summary>
-        [Obsolete("Color is obsolete. Use DrawingColor for full Color support.")]
+        [Obsolete("Color is obsolete. Use DrawingColor for full Color support. This will be removed in a future update.", true)]
         public ConsoleColor Color
         {
             get => LoggerUtils.DrawingColorToConsoleColor(DrawingColor);
@@ -25,7 +25,7 @@ namespace MelonLoader
         public MelonColorAttribute() 
             => DrawingColor = MelonLogger.DefaultTextColor;
 
-        [Obsolete("ConsoleColor is obsolete, use the (int, int, int, int) constructor instead.")]
+        [Obsolete("ConsoleColor is obsolete, use the (int, int, int, int) constructor instead. This will be removed in a future update.", true)]
         public MelonColorAttribute(ConsoleColor color) 
             => Color = ((color == ConsoleColor.Black) ? LoggerUtils.DrawingColorToConsoleColor(MelonLogger.DefaultMelonColor) : color);
 

--- a/MelonLoader/Attributes/MelonGameAttribute.cs
+++ b/MelonLoader/Attributes/MelonGameAttribute.cs
@@ -37,13 +37,13 @@ namespace MelonLoader
         /// </summary>
         public bool IsCompatibleBecauseUniversal(MelonGameAttribute att) => ((att == null) || Universal || att.Universal);
 
-        [Obsolete("IsCompatible(MelonModGameAttribute) is obsolete. Please use IsCompatible(MelonGameAttribute) instead.")]
+        [Obsolete("IsCompatible(MelonModGameAttribute) is obsolete. Please use IsCompatible(MelonGameAttribute) instead. This will be removed in a future update.", true)]
         public bool IsCompatible(MelonModGameAttribute att) => ((att == null) || IsCompatibleBecauseUniversal(att) || (att.Developer.Equals(Developer) && att.GameName.Equals(Name)));
-        [Obsolete("IsCompatible(MelonPluginGameAttribute) is obsolete. Please use IsCompatible(MelonGameAttribute) instead.")]
+        [Obsolete("IsCompatible(MelonPluginGameAttribute) is obsolete. Please use IsCompatible(MelonGameAttribute) instead. This will be removed in a future update.", true)]
         public bool IsCompatible(MelonPluginGameAttribute att) => ((att == null) || IsCompatibleBecauseUniversal(att) || (att.Developer.Equals(Developer) && att.GameName.Equals(Name)));
-        [Obsolete("IsCompatibleBecauseUniversal(MelonModGameAttribute) is obsolete. Please use IsCompatible(MelonGameAttribute) instead.")]
+        [Obsolete("IsCompatibleBecauseUniversal(MelonModGameAttribute) is obsolete. Please use IsCompatible(MelonGameAttribute) instead. This will be removed in a future update.", true)]
         public bool IsCompatibleBecauseUniversal(MelonModGameAttribute att) => ((att == null) || Universal || (string.IsNullOrEmpty(att.Developer) || string.IsNullOrEmpty(att.GameName)));
-        [Obsolete("IsCompatibleBecauseUniversal(MelonPluginGameAttribute) is obsolete. Please use IsCompatible(MelonGameAttribute) instead.")]
+        [Obsolete("IsCompatibleBecauseUniversal(MelonPluginGameAttribute) is obsolete. Please use IsCompatible(MelonGameAttribute) instead. This will be removed in a future update.", true)]
         public bool IsCompatibleBecauseUniversal(MelonPluginGameAttribute att) => ((att == null) || Universal || (string.IsNullOrEmpty(att.Developer) || string.IsNullOrEmpty(att.GameName)));
     }
 }

--- a/MelonLoader/BackwardsCompatibility/Harmony/Attributes.cs
+++ b/MelonLoader/BackwardsCompatibility/Harmony/Attributes.cs
@@ -2,7 +2,7 @@
 
 namespace Harmony
 {
-	[Obsolete("Harmony.MethodType is Only Here for Compatibility Reasons. Please use HarmonyLib.MethodType instead.")]
+	[Obsolete("Harmony.MethodType is Only Here for Compatibility Reasons. Please use HarmonyLib.MethodType instead. This will be removed in a future update.", true)]
 	public enum MethodType
 	{
 		Normal = HarmonyLib.MethodType.Normal,
@@ -12,14 +12,14 @@ namespace Harmony
 		StaticConstructor = HarmonyLib.MethodType.StaticConstructor
 	}
 
-	[Obsolete("Harmony.PropertyMethod is Only Here for Compatibility Reasons. Please use HarmonyLib.MethodType instead.")]
+	[Obsolete("Harmony.PropertyMethod is Only Here for Compatibility Reasons. Please use HarmonyLib.MethodType instead. This will be removed in a future update.", true)]
 	public enum PropertyMethod
 	{
 		Getter = HarmonyLib.MethodType.Getter,
 		Setter = HarmonyLib.MethodType.Setter
 	}
 
-	[Obsolete("Harmony.ArgumentType is Only Here for Compatibility Reasons. Please use HarmonyLib.ArgumentType instead.")]
+	[Obsolete("Harmony.ArgumentType is Only Here for Compatibility Reasons. Please use HarmonyLib.ArgumentType instead. This will be removed in a future update.", true)]
 	public enum ArgumentType
 	{
 		Normal = HarmonyLib.ArgumentType.Normal,
@@ -28,7 +28,7 @@ namespace Harmony
 		Pointer = HarmonyLib.ArgumentType.Pointer
 	}
 
-	[Obsolete("Harmony.HarmonyPatchType is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatchType instead.")]
+	[Obsolete("Harmony.HarmonyPatchType is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatchType instead. This will be removed in a future update.", true)]
 	public enum HarmonyPatchType
 	{
 		All = HarmonyLib.HarmonyPatchType.All,
@@ -37,124 +37,124 @@ namespace Harmony
 		Transpiler = HarmonyLib.HarmonyPatchType.Transpiler
 	}
 
-	[Obsolete("Harmony.HarmonyAttribute is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyAttribute instead.")]
+	[Obsolete("Harmony.HarmonyAttribute is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyAttribute instead. This will be removed in a future update.", true)]
 	public class HarmonyAttribute : HarmonyLib.HarmonyAttribute { }
 
-	[Obsolete("Harmony.HarmonyPatch is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatch instead.")]
+	[Obsolete("Harmony.HarmonyPatch is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatch instead. This will be removed in a future update.", true)]
 	[AttributeUsage(AttributeTargets.Class | AttributeTargets.Delegate | AttributeTargets.Method, AllowMultiple = true)]
 	public class HarmonyPatch : HarmonyLib.HarmonyPatch
 	{
-		[Obsolete("Harmony.HarmonyPatch is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatch instead.")]
+		[Obsolete("Harmony.HarmonyPatch is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatch instead. This will be removed in a future update.", true)]
 		public HarmonyPatch() : base() { }
-		[Obsolete("Harmony.HarmonyPatch is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatch instead.")]
+		[Obsolete("Harmony.HarmonyPatch is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatch instead. This will be removed in a future update.", true)]
 		public HarmonyPatch(Type declaringType) : base(declaringType) { }
-		[Obsolete("Harmony.HarmonyPatch is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatch instead.")]
+		[Obsolete("Harmony.HarmonyPatch is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatch instead. This will be removed in a future update.", true)]
 		public HarmonyPatch(Type declaringType, Type[] argumentTypes) : base(declaringType, argumentTypes) { }
-		[Obsolete("Harmony.HarmonyPatch is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatch instead.")]
+		[Obsolete("Harmony.HarmonyPatch is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatch instead. This will be removed in a future update.", true)]
 		public HarmonyPatch(Type declaringType, string methodName) : base(declaringType, methodName) { }
-		[Obsolete("Harmony.HarmonyPatch is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatch instead.")]
+		[Obsolete("Harmony.HarmonyPatch is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatch instead. This will be removed in a future update.", true)]
 		public HarmonyPatch(Type declaringType, string methodName, params Type[] argumentTypes) : base(declaringType, methodName, argumentTypes) { }
-		[Obsolete("Harmony.HarmonyPatch is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatch instead.")]
+		[Obsolete("Harmony.HarmonyPatch is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatch instead. This will be removed in a future update.", true)]
 		public HarmonyPatch(Type declaringType, string methodName, Type[] argumentTypes, ArgumentType[] argumentVariations) : base(declaringType, methodName, argumentTypes, Array.ConvertAll(argumentVariations, x => (HarmonyLib.ArgumentType)x)) { }
-		[Obsolete("Harmony.HarmonyPatch is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatch instead.")]
+		[Obsolete("Harmony.HarmonyPatch is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatch instead. This will be removed in a future update.", true)]
 		public HarmonyPatch(Type declaringType, MethodType methodType) : base(declaringType, (HarmonyLib.MethodType)methodType) { }
-		[Obsolete("Harmony.HarmonyPatch is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatch instead.")]
+		[Obsolete("Harmony.HarmonyPatch is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatch instead. This will be removed in a future update.", true)]
 		public HarmonyPatch(Type declaringType, MethodType methodType, params Type[] argumentTypes) : base(declaringType, (HarmonyLib.MethodType)methodType, argumentTypes) { }
-		[Obsolete("Harmony.HarmonyPatch is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatch instead.")]
+		[Obsolete("Harmony.HarmonyPatch is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatch instead. This will be removed in a future update.", true)]
 		public HarmonyPatch(Type declaringType, MethodType methodType, Type[] argumentTypes, ArgumentType[] argumentVariations) : base(declaringType, (HarmonyLib.MethodType)methodType, argumentTypes, Array.ConvertAll(argumentVariations, x => (HarmonyLib.ArgumentType)x)) { }
-		[Obsolete("Harmony.HarmonyPatch is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatch instead.")]
+		[Obsolete("Harmony.HarmonyPatch is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatch instead. This will be removed in a future update.", true)]
 		public HarmonyPatch(Type declaringType, string propertyName, MethodType methodType) : base(declaringType, propertyName, (HarmonyLib.MethodType)methodType) { }
-		[Obsolete("Harmony.HarmonyPatch is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatch instead.")]
+		[Obsolete("Harmony.HarmonyPatch is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatch instead. This will be removed in a future update.", true)]
 		public HarmonyPatch(string methodName) : base(methodName) { }
-		[Obsolete("Harmony.HarmonyPatch is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatch instead.")]
+		[Obsolete("Harmony.HarmonyPatch is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatch instead. This will be removed in a future update.", true)]
 		public HarmonyPatch(string methodName, params Type[] argumentTypes) : base(methodName, argumentTypes) { }
-		[Obsolete("Harmony.HarmonyPatch is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatch instead.")]
+		[Obsolete("Harmony.HarmonyPatch is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatch instead. This will be removed in a future update.", true)]
 		public HarmonyPatch(string methodName, Type[] argumentTypes, ArgumentType[] argumentVariations) : base(methodName, argumentTypes, Array.ConvertAll(argumentVariations, x => (HarmonyLib.ArgumentType)x)) { }
-		[Obsolete("Harmony.HarmonyPatch is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatch instead.")]
+		[Obsolete("Harmony.HarmonyPatch is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatch instead. This will be removed in a future update.", true)]
 		public HarmonyPatch(string propertyName, MethodType methodType) : base(propertyName, (HarmonyLib.MethodType)methodType) { }
-		[Obsolete("Harmony.HarmonyPatch is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatch instead.")]
+		[Obsolete("Harmony.HarmonyPatch is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatch instead. This will be removed in a future update.", true)]
 		public HarmonyPatch(MethodType methodType) : base((HarmonyLib.MethodType)methodType) { }
-		[Obsolete("Harmony.HarmonyPatch is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatch instead.")]
+		[Obsolete("Harmony.HarmonyPatch is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatch instead. This will be removed in a future update.", true)]
 		public HarmonyPatch(MethodType methodType, params Type[] argumentTypes) : base((HarmonyLib.MethodType)methodType, argumentTypes) { }
-		[Obsolete("Harmony.HarmonyPatch is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatch instead.")]
+		[Obsolete("Harmony.HarmonyPatch is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatch instead. This will be removed in a future update.", true)]
 		public HarmonyPatch(MethodType methodType, Type[] argumentTypes, ArgumentType[] argumentVariations) : base((HarmonyLib.MethodType)methodType, argumentTypes, Array.ConvertAll(argumentVariations, x => (HarmonyLib.ArgumentType)x)) { }
-		[Obsolete("Harmony.HarmonyPatch is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatch instead.")]
+		[Obsolete("Harmony.HarmonyPatch is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatch instead. This will be removed in a future update.", true)]
 		public HarmonyPatch(Type[] argumentTypes) : base(argumentTypes) { }
-		[Obsolete("Harmony.HarmonyPatch is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatch instead.")]
+		[Obsolete("Harmony.HarmonyPatch is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatch instead. This will be removed in a future update.", true)]
 		public HarmonyPatch(Type[] argumentTypes, ArgumentType[] argumentVariations) : base(argumentTypes, Array.ConvertAll(argumentVariations, x => (HarmonyLib.ArgumentType)x)) { }
-		[Obsolete("Harmony.HarmonyPatch is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatch instead.")]
+		[Obsolete("Harmony.HarmonyPatch is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatch instead. This will be removed in a future update.", true)]
 		public HarmonyPatch(string propertyName, PropertyMethod type) : base(propertyName, (HarmonyLib.MethodType)type) { }
-		[Obsolete("Harmony.HarmonyPatch is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatch instead.")]
+		[Obsolete("Harmony.HarmonyPatch is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatch instead. This will be removed in a future update.", true)]
 		public HarmonyPatch(string assemblyQualifiedDeclaringType, string methodName, MethodType methodType, Type[] argumentTypes = null, ArgumentType[] argumentVariations = null) : base(assemblyQualifiedDeclaringType, methodName, (HarmonyLib.MethodType)methodType, argumentTypes, Array.ConvertAll(argumentVariations, x => (HarmonyLib.ArgumentType)x)) { }
 	}
 
-	[Obsolete("Harmony.HarmonyPatchAll is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatchAll instead.")]
+	[Obsolete("Harmony.HarmonyPatchAll is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPatchAll instead. This will be removed in a future update.", true)]
 	[AttributeUsage(AttributeTargets.Class)]
 	public class HarmonyPatchAll : HarmonyLib.HarmonyPatchAll { }
 
-	[Obsolete("Harmony.HarmonyPriority is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPriority instead.")]
+	[Obsolete("Harmony.HarmonyPriority is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPriority instead. This will be removed in a future update.", true)]
 	[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
 	public class HarmonyPriority : HarmonyLib.HarmonyPriority
 	{
-		[Obsolete("Harmony.HarmonyPriority is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPriority instead.")]
+		[Obsolete("Harmony.HarmonyPriority is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPriority instead. This will be removed in a future update.", true)]
 		public HarmonyPriority(int prioritiy) : base(prioritiy) { }
 	}
 
-	[Obsolete("Harmony.HarmonyBefore is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyBefore instead.")]
+	[Obsolete("Harmony.HarmonyBefore is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyBefore instead. This will be removed in a future update.", true)]
 	[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
 	public class HarmonyBefore : HarmonyLib.HarmonyBefore
 	{
-		[Obsolete("Harmony.HarmonyBefore is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyBefore instead.")]
+		[Obsolete("Harmony.HarmonyBefore is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyBefore instead. This will be removed in a future update.", true)]
 		public HarmonyBefore(params string[] before) : base(before) { }
 	}
 
-	[Obsolete("Harmony.HarmonyAfter is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyAfter instead.")]
+	[Obsolete("Harmony.HarmonyAfter is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyAfter instead. This will be removed in a future update.", true)]
 	[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
 	public class HarmonyAfter : HarmonyLib.HarmonyAfter
 	{
-		[Obsolete("Harmony.HarmonyAfter is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyAfter instead.")]
+		[Obsolete("Harmony.HarmonyAfter is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyAfter instead. This will be removed in a future update.", true)]
 		public HarmonyAfter(params string[] after) : base(after) { }
 	}
 
-	[Obsolete("Harmony.HarmonyPrepare is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPrepare instead.")]
+	[Obsolete("Harmony.HarmonyPrepare is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPrepare instead. This will be removed in a future update.", true)]
 	[AttributeUsage(AttributeTargets.Method)]
 	public class HarmonyPrepare : HarmonyLib.HarmonyPrepare { }
 
-	[Obsolete("Harmony.HarmonyCleanup is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyCleanup instead.")]
+	[Obsolete("Harmony.HarmonyCleanup is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyCleanup instead. This will be removed in a future update.", true)]
 	[AttributeUsage(AttributeTargets.Method)]
 	public class HarmonyCleanup : HarmonyLib.HarmonyCleanup { }
 
-	[Obsolete("Harmony.HarmonyTargetMethod is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyTargetMethod instead.")]
+	[Obsolete("Harmony.HarmonyTargetMethod is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyTargetMethod instead. This will be removed in a future update.", true)]
 	[AttributeUsage(AttributeTargets.Method)]
 	public class HarmonyTargetMethod : HarmonyLib.HarmonyTargetMethod { }
 
-	[Obsolete("Harmony.HarmonyTargetMethods is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyTargetMethods instead.")]
+	[Obsolete("Harmony.HarmonyTargetMethods is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyTargetMethods instead. This will be removed in a future update.", true)]
 	[AttributeUsage(AttributeTargets.Method)]
 	public class HarmonyTargetMethods : HarmonyLib.HarmonyTargetMethods { }
 
-	[Obsolete("Harmony.HarmonyPrefix is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPrefix instead.")]
+	[Obsolete("Harmony.HarmonyPrefix is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPrefix instead. This will be removed in a future update.", true)]
 	[AttributeUsage(AttributeTargets.Method)]
 	public class HarmonyPrefix : HarmonyLib.HarmonyPrefix { }
 
-	[Obsolete("Harmony.HarmonyPostfix is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPostfix instead.")]
+	[Obsolete("Harmony.HarmonyPostfix is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyPostfix instead. This will be removed in a future update.", true)]
 	[AttributeUsage(AttributeTargets.Method)]
 	public class HarmonyPostfix : HarmonyLib.HarmonyPostfix { }
 
-	[Obsolete("Harmony.HarmonyTranspiler is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyTranspiler instead.")]
+	[Obsolete("Harmony.HarmonyTranspiler is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyTranspiler instead. This will be removed in a future update.", true)]
 	[AttributeUsage(AttributeTargets.Method)]
 	public class HarmonyTranspiler : HarmonyLib.HarmonyTranspiler { }
 
-	[Obsolete("Harmony.HarmonyArgument is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyArgument instead.")]
+	[Obsolete("Harmony.HarmonyArgument is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyArgument instead. This will be removed in a future update.", true)]
 	[AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = true)]
 	public class HarmonyArgument : HarmonyLib.HarmonyArgument
 	{
-		[Obsolete("Harmony.HarmonyArgument is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyArgument instead.")]
+		[Obsolete("Harmony.HarmonyArgument is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyArgument instead. This will be removed in a future update.", true)]
 		public HarmonyArgument(string originalName) : base(originalName, null) { }
-		[Obsolete("Harmony.HarmonyArgument is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyArgument instead.")]
+		[Obsolete("Harmony.HarmonyArgument is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyArgument instead. This will be removed in a future update.", true)]
 		public HarmonyArgument(int index) : base(index, null) { }
-		[Obsolete("Harmony.HarmonyArgument is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyArgument instead.")]
+		[Obsolete("Harmony.HarmonyArgument is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyArgument instead. This will be removed in a future update.", true)]
 		public HarmonyArgument(string originalName, string newName) : base(originalName, newName) { }
-		[Obsolete("Harmony.HarmonyArgument is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyArgument instead.")]
+		[Obsolete("Harmony.HarmonyArgument is Only Here for Compatibility Reasons. Please use HarmonyLib.HarmonyArgument instead. This will be removed in a future update.", true)]
 		public HarmonyArgument(int index, string name) : base(index, name) { }
 	}
 }

--- a/MelonLoader/BackwardsCompatibility/Harmony/Extras/FastAccess.cs
+++ b/MelonLoader/BackwardsCompatibility/Harmony/Extras/FastAccess.cs
@@ -11,8 +11,8 @@ namespace Harmony
 
 	public class FastAccess
 	{
-		[Obsolete("Use AccessTools.MethodDelegate<Func<T, S>>(PropertyInfo.GetGetMethod(true))")]
-		public static InstantiationHandler CreateInstantiationHandler(Type type)
+		[Obsolete("Use AccessTools.MethodDelegate<Func<T, S>>(PropertyInfo.GetGetMethod(true)). This will be removed in a future update.", true)]
+        public static InstantiationHandler CreateInstantiationHandler(Type type)
 		{
 			var constructorInfo = type.GetConstructor(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance, null, new Type[0], null);
 			if (constructorInfo is null)
@@ -24,8 +24,8 @@ namespace Harmony
 			return (InstantiationHandler)dynamicMethod.Generate().CreateDelegate(typeof(InstantiationHandler));
 		}
 
-		[Obsolete("Use AccessTools.MethodDelegate<Func<T, S>>(PropertyInfo.GetGetMethod(true))")]
-		public static GetterHandler CreateGetterHandler(PropertyInfo propertyInfo)
+		[Obsolete("Use AccessTools.MethodDelegate<Func<T, S>>(PropertyInfo.GetGetMethod(true)). This will be removed in a future update.", true)]
+        public static GetterHandler CreateGetterHandler(PropertyInfo propertyInfo)
 		{
 			var getMethodInfo = propertyInfo.GetGetMethod(true);
 			var dynamicGet = CreateGetDynamicMethod(propertyInfo.DeclaringType);
@@ -36,8 +36,8 @@ namespace Harmony
 			return (GetterHandler)dynamicGet.Generate().CreateDelegate(typeof(GetterHandler));
 		}
 
-		[Obsolete("Use AccessTools.FieldRefAccess<T, S>(fieldInfo)")]
-		public static GetterHandler CreateGetterHandler(FieldInfo fieldInfo)
+		[Obsolete("Use AccessTools.FieldRefAccess<T, S>(fieldInfo). This will be removed in a future update.", true)]
+        public static GetterHandler CreateGetterHandler(FieldInfo fieldInfo)
 		{
 			var dynamicGet = CreateGetDynamicMethod(fieldInfo.DeclaringType);
 			var getGenerator = dynamicGet.GetILGenerator();
@@ -48,8 +48,8 @@ namespace Harmony
 		}
 
 		[Obsolete("Use AccessTools.FieldRefAccess<T, S>(name) for fields and " +
-			"AccessTools.MethodDelegate<Func<T, S>>(AccessTools.PropertyGetter(typeof(T), name)) for properties")]
-		public static GetterHandler CreateFieldGetter(Type type, params string[] names)
+            "AccessTools.MethodDelegate<Func<T, S>>(AccessTools.PropertyGetter(typeof(T), name)) for properties. This will be removed in a future update.", true)]
+        public static GetterHandler CreateFieldGetter(Type type, params string[] names)
 		{
 			foreach (var name in names)
 			{
@@ -63,8 +63,8 @@ namespace Harmony
 			return null;
 		}
 
-		[Obsolete("Use AccessTools.MethodDelegate<Action<T, S>>(PropertyInfo.GetSetMethod(true))")]
-		public static SetterHandler CreateSetterHandler(PropertyInfo propertyInfo)
+		[Obsolete("Use AccessTools.MethodDelegate<Action<T, S>>(PropertyInfo.GetSetMethod(true)). This will be removed in a future update.", true)]
+        public static SetterHandler CreateSetterHandler(PropertyInfo propertyInfo)
 		{
 			var setMethodInfo = propertyInfo.GetSetMethod(true);
 			var dynamicSet = CreateSetDynamicMethod(propertyInfo.DeclaringType);
@@ -76,8 +76,8 @@ namespace Harmony
 			return (SetterHandler)dynamicSet.Generate().CreateDelegate(typeof(SetterHandler));
 		}
 
-		[Obsolete("Use AccessTools.FieldRefAccess<T, S>(fieldInfo)")]
-		public static SetterHandler CreateSetterHandler(FieldInfo fieldInfo)
+		[Obsolete("Use AccessTools.FieldRefAccess<T, S>(fieldInfo). This will be removed in a future update.", true)]
+        public static SetterHandler CreateSetterHandler(FieldInfo fieldInfo)
 		{
 			var dynamicSet = CreateSetDynamicMethod(fieldInfo.DeclaringType);
 			var setGenerator = dynamicSet.GetILGenerator();

--- a/MelonLoader/BackwardsCompatibility/Harmony/HarmonyInstance.cs
+++ b/MelonLoader/BackwardsCompatibility/Harmony/HarmonyInstance.cs
@@ -5,19 +5,20 @@ using System.Reflection.Emit;
 
 namespace Harmony
 {
-	public class HarmonyInstance : HarmonyLib.Harmony
+    [Obsolete("Harmony.HarmonyInstance is obsolete. Please use HarmonyLib.Harmony instead. This will be removed in a future update.", true)]
+    public class HarmonyInstance : HarmonyLib.Harmony
 	{
-		[Obsolete("Harmony.HarmonyInstance is obsolete. Please use HarmonyLib.Harmony instead.")]
+		[Obsolete("Harmony.HarmonyInstance is obsolete. Please use HarmonyLib.Harmony instead. This will be removed in a future update.", true)]
 		public HarmonyInstance(string id) : base(id) { }
 
-		[Obsolete("Harmony.HarmonyInstance.Create is obsolete. Please use the HarmonyLib.Harmony Constructor instead.")]
+		[Obsolete("Harmony.HarmonyInstance.Create is obsolete. Please use the HarmonyLib.Harmony Constructor instead. This will be removed in a future update.", true)]
 		public static HarmonyInstance Create(string id)
 		{
 			if (id == null) throw new Exception("id cannot be null");
 			return new HarmonyInstance(id);
 		}
 
-		[Obsolete("Harmony.HarmonyInstance.Patch is obsolete. Please use HarmonyLib.Harmony.Patch instead.")]
+		[Obsolete("Harmony.HarmonyInstance.Patch is obsolete. Please use HarmonyLib.Harmony.Patch instead. This will be removed in a future update.", true)]
 		public DynamicMethod Patch(MethodBase original, HarmonyMethod prefix = null, HarmonyMethod postfix = null, HarmonyMethod transpiler = null)
 		{
 			base.Patch(original, prefix, postfix, transpiler);

--- a/MelonLoader/BackwardsCompatibility/Harmony/HarmonyMethod.cs
+++ b/MelonLoader/BackwardsCompatibility/Harmony/HarmonyMethod.cs
@@ -5,34 +5,34 @@ using System.Reflection;
 
 namespace Harmony
 {
-	[Obsolete("Harmony.HarmonyMethod is obsolete. Please use HarmonyLib.HarmonyMethod instead.")]
+	[Obsolete("Harmony.HarmonyMethod is obsolete. Please use HarmonyLib.HarmonyMethod instead. This will be removed in a future update.", true)]
 	public class HarmonyMethod : HarmonyLib.HarmonyMethod
 	{
-		[Obsolete("Harmony.HarmonyMethod.prioritiy is obsolete. Please use HarmonyLib.HarmonyMethod.priority instead.")]
+		[Obsolete("Harmony.HarmonyMethod.prioritiy is obsolete. Please use HarmonyLib.HarmonyMethod.priority instead. This will be removed in a future update.", true)]
 		public int prioritiy = -1;
-		[Obsolete("Harmony.HarmonyMethod is obsolete. Please use HarmonyLib.HarmonyMethod instead.")]
+		[Obsolete("Harmony.HarmonyMethod is obsolete. Please use HarmonyLib.HarmonyMethod instead. This will be removed in a future update.", true)]
 		public HarmonyMethod() : base() { }
-		[Obsolete("Harmony.HarmonyMethod is obsolete. Please use HarmonyLib.HarmonyMethod instead.")]
+		[Obsolete("Harmony.HarmonyMethod is obsolete. Please use HarmonyLib.HarmonyMethod instead. This will be removed in a future update.", true)]
 		public HarmonyMethod(MethodInfo method) : base(method) { }
-		[Obsolete("Harmony.HarmonyMethod is obsolete. Please use HarmonyLib.HarmonyMethod instead.")]
+		[Obsolete("Harmony.HarmonyMethod is obsolete. Please use HarmonyLib.HarmonyMethod instead. This will be removed in a future update.", true)]
 		public HarmonyMethod(Type type, string name, Type[] parameters = null) : base(type, name, parameters) { }
-		[Obsolete("Harmony.HarmonyMethod.Merge is obsolete. Please use HarmonyLib.HarmonyMethod.Merge instead.")]
+		[Obsolete("Harmony.HarmonyMethod.Merge is obsolete. Please use HarmonyLib.HarmonyMethod.Merge instead. This will be removed in a future update.", true)]
 		public static HarmonyMethod Merge(List<HarmonyMethod> attributes) => (HarmonyMethod)Merge(Array.ConvertAll(attributes.ToArray(), x => (HarmonyLib.HarmonyMethod)x).ToList());
 		public override string ToString() => base.ToString();
 	}
 
-	[Obsolete("Harmony.HarmonyMethodExtensions is obsolete. Please use HarmonyLib.HarmonyMethodExtensions instead.")]
+	[Obsolete("Harmony.HarmonyMethodExtensions is obsolete. Please use HarmonyLib.HarmonyMethodExtensions instead. This will be removed in a future update.", true)]
 	public static class HarmonyMethodExtensions
 	{
-		[Obsolete("Harmony.HarmonyMethodExtensions.CopyTo is obsolete. Please use HarmonyLib.HarmonyMethodExtensions.CopyTo instead.")]
+		[Obsolete("Harmony.HarmonyMethodExtensions.CopyTo is obsolete. Please use HarmonyLib.HarmonyMethodExtensions.CopyTo instead. This will be removed in a future update.", true)]
 		public static void CopyTo(this HarmonyMethod from, HarmonyMethod to) => HarmonyLib.HarmonyMethodExtensions.CopyTo(from, to);
-		[Obsolete("Harmony.HarmonyMethodExtensions.Clone is obsolete. Please use HarmonyLib.HarmonyMethodExtensions.Clone instead.")]
+		[Obsolete("Harmony.HarmonyMethodExtensions.Clone is obsolete. Please use HarmonyLib.HarmonyMethodExtensions.Clone instead. This will be removed in a future update.", true)]
 		public static HarmonyMethod Clone(this HarmonyMethod original) => (HarmonyMethod)HarmonyLib.HarmonyMethodExtensions.Clone(original);
-		[Obsolete("Harmony.HarmonyMethodExtensions.Merge is obsolete. Please use HarmonyLib.HarmonyMethodExtensions.Merge instead.")]
+		[Obsolete("Harmony.HarmonyMethodExtensions.Merge is obsolete. Please use HarmonyLib.HarmonyMethodExtensions.Merge instead. This will be removed in a future update.", true)]
 		public static HarmonyMethod Merge(this HarmonyMethod master, HarmonyMethod detail) => (HarmonyMethod)HarmonyLib.HarmonyMethodExtensions.Merge(master, detail);
-		[Obsolete("Harmony.HarmonyMethodExtensions.GetHarmonyMethods(Type) is obsolete. Please use HarmonyLib.HarmonyMethodExtensions.GetFromType instead.")]
+		[Obsolete("Harmony.HarmonyMethodExtensions.GetHarmonyMethods(Type) is obsolete. Please use HarmonyLib.HarmonyMethodExtensions.GetFromType instead. This will be removed in a future update.", true)]
 		public static List<HarmonyMethod> GetHarmonyMethods(this Type type) => Array.ConvertAll(HarmonyLib.HarmonyMethodExtensions.GetFromType(type).ToArray(), x => (HarmonyMethod)x).ToList();
-		[Obsolete("Harmony.HarmonyMethodExtensions.GetHarmonyMethods(MethodBase) is obsolete. Please use HarmonyLib.HarmonyMethodExtensions.GetFromMethod instead.")]
+		[Obsolete("Harmony.HarmonyMethodExtensions.GetHarmonyMethods(MethodBase) is obsolete. Please use HarmonyLib.HarmonyMethodExtensions.GetFromMethod instead. This will be removed in a future update.", true)]
 		public static List<HarmonyMethod> GetHarmonyMethods(this MethodBase method) => Array.ConvertAll(HarmonyLib.HarmonyMethodExtensions.GetFromMethod(method).ToArray(), x => (HarmonyMethod)x).ToList();
 	}
 }

--- a/MelonLoader/BackwardsCompatibility/Harmony/Patch.cs
+++ b/MelonLoader/BackwardsCompatibility/Harmony/Patch.cs
@@ -4,7 +4,7 @@ using MonoMod.Utils;
 
 namespace Harmony
 {
-	[Obsolete("Harmony.PatchInfoSerialization is Only Here for Compatibility Reasons. Please use HarmonyLib.PatchInfoSerialization instead.")]
+	[Obsolete("Harmony.PatchInfoSerialization is Only Here for Compatibility Reasons. Please use HarmonyLib.PatchInfoSerialization instead. This will be removed in a future update.", true)]
 	public static class PatchInfoSerialization
 	{
 		private delegate HarmonyLib.PatchInfo HarmonyLib_PatchInfoSerialization_Deserialize_Delegate(byte[] bytes);
@@ -15,23 +15,23 @@ namespace Harmony
 		private static HarmonyLib_PatchInfoSerialization_PriorityComparer_Delegate HarmonyLib_PatchInfoSerialization_PriorityComparer
 			= HarmonyLib.AccessTools.Method("HarmonyLib.PatchInfoSerialization:PriorityComparer").CreateDelegate<HarmonyLib_PatchInfoSerialization_PriorityComparer_Delegate>();
 
-		[Obsolete("Harmony.PatchInfoSerialization.Deserialize is Only Here for Compatibility Reasons. Please use HarmonyLib.PatchInfoSerialization.Deserialize instead.")]
+		[Obsolete("Harmony.PatchInfoSerialization.Deserialize is Only Here for Compatibility Reasons. Please use HarmonyLib.PatchInfoSerialization.Deserialize instead. This will be removed in a future update.", true)]
 		public static PatchInfo Deserialize(byte[] bytes) => (PatchInfo)HarmonyLib_PatchInfoSerialization_Deserialize(bytes);
-		[Obsolete("Harmony.PatchInfoSerialization.PriorityComparer is Only Here for Compatibility Reasons. Please use HarmonyLib.PatchInfoSerialization.PriorityComparer instead.")]
+		[Obsolete("Harmony.PatchInfoSerialization.PriorityComparer is Only Here for Compatibility Reasons. Please use HarmonyLib.PatchInfoSerialization.PriorityComparer instead. This will be removed in a future update.", true)]
 		public static int PriorityComparer(object obj, int index, int priority, string[] before, string[] after) => HarmonyLib_PatchInfoSerialization_PriorityComparer(obj, index, priority);
 	}
 
-	[Obsolete("Harmony.PatchInfo is Only Here for Compatibility Reasons. Please use HarmonyLib.PatchInfo instead.")]
+	[Obsolete("Harmony.PatchInfo is Only Here for Compatibility Reasons. Please use HarmonyLib.PatchInfo instead. This will be removed in a future update.", true)]
 	[Serializable]
 	public class PatchInfo : HarmonyLib.PatchInfo { }
 
-	[Obsolete("Harmony.Patch is Only Here for Compatibility Reasons. Please use HarmonyLib.Patch instead.")]
+	[Obsolete("Harmony.Patch is Only Here for Compatibility Reasons. Please use HarmonyLib.Patch instead. This will be removed in a future update.", true)]
 	[Serializable]
 	public class Patch : IComparable
 	{
 		readonly public MethodInfo patch;
 		private HarmonyLib.Patch patchWrapper;
-		[Obsolete("Harmony.Patch is Only Here for Compatibility Reasons. Please use HarmonyLib.Patch instead.")]
+		[Obsolete("Harmony.Patch is Only Here for Compatibility Reasons. Please use HarmonyLib.Patch instead. This will be removed in a future update.", true)]
 		public Patch(MethodInfo patch, int index, string owner, int priority, string[] before, string[] after) 
 		{
 			this.patch = patch;

--- a/MelonLoader/BackwardsCompatibility/Harmony/Priority.cs
+++ b/MelonLoader/BackwardsCompatibility/Harmony/Priority.cs
@@ -2,26 +2,26 @@
 
 namespace Harmony
 {
-	[Obsolete("Harmony.Priority is Only Here for Compatibility Reasons. Please use HarmonyLib.Priority instead.")]
+	[Obsolete("Harmony.Priority is Only Here for Compatibility Reasons. Please use HarmonyLib.Priority instead. This will be removed in a future update.", true)]
 	public static class Priority
 	{
-		[Obsolete("Harmony.Priority.Last is Only Here for Compatibility Reasons. Please use HarmonyLib.Priority.Last instead.")]
+		[Obsolete("Harmony.Priority.Last is Only Here for Compatibility Reasons. Please use HarmonyLib.Priority.Last instead. This will be removed in a future update.", true)]
 		public const int Last = HarmonyLib.Priority.Last;
-		[Obsolete("Harmony.Priority.VeryLow is Only Here for Compatibility Reasons. Please use HarmonyLib.Priority.VeryLow instead.")]
+		[Obsolete("Harmony.Priority.VeryLow is Only Here for Compatibility Reasons. Please use HarmonyLib.Priority.VeryLow instead. This will be removed in a future update.", true)]
 		public const int VeryLow = HarmonyLib.Priority.VeryLow;
-		[Obsolete("Harmony.Priority.Low is Only Here for Compatibility Reasons. Please use HarmonyLib.Priority.Low instead.")]
+		[Obsolete("Harmony.Priority.Low is Only Here for Compatibility Reasons. Please use HarmonyLib.Priority.Low instead. This will be removed in a future update.", true)]
 		public const int Low = HarmonyLib.Priority.Low;
-		[Obsolete("Harmony.Priority.LowerThanNormal is Only Here for Compatibility Reasons. Please use HarmonyLib.Priority.LowerThanNormal instead.")]
+		[Obsolete("Harmony.Priority.LowerThanNormal is Only Here for Compatibility Reasons. Please use HarmonyLib.Priority.LowerThanNormal instead. This will be removed in a future update.", true)]
 		public const int LowerThanNormal = HarmonyLib.Priority.LowerThanNormal;
-		[Obsolete("Harmony.Priority.Normal is Only Here for Compatibility Reasons. Please use HarmonyLib.Priority.Normal instead.")]
+		[Obsolete("Harmony.Priority.Normal is Only Here for Compatibility Reasons. Please use HarmonyLib.Priority.Normal instead. This will be removed in a future update.", true)]
 		public const int Normal = HarmonyLib.Priority.Normal;
-		[Obsolete("Harmony.Priority.HigherThanNormal is Only Here for Compatibility Reasons. Please use HarmonyLib.Priority.HigherThanNormal instead.")]
+		[Obsolete("Harmony.Priority.HigherThanNormal is Only Here for Compatibility Reasons. Please use HarmonyLib.Priority.HigherThanNormal instead. This will be removed in a future update.", true)]
 		public const int HigherThanNormal = HarmonyLib.Priority.HigherThanNormal;
-		[Obsolete("Harmony.Priority.High is Only Here for Compatibility Reasons. Please use HarmonyLib.Priority.High instead.")]
+		[Obsolete("Harmony.Priority.High is Only Here for Compatibility Reasons. Please use HarmonyLib.Priority.High instead. This will be removed in a future update.", true)]
 		public const int High = HarmonyLib.Priority.High;
-		[Obsolete("Harmony.Priority.VeryHigh is Only Here for Compatibility Reasons. Please use HarmonyLib.Priority.VeryHigh instead.")]
+		[Obsolete("Harmony.Priority.VeryHigh is Only Here for Compatibility Reasons. Please use HarmonyLib.Priority.VeryHigh instead. This will be removed in a future update.", true)]
 		public const int VeryHigh = HarmonyLib.Priority.VeryHigh;
-		[Obsolete("Harmony.Priority.First is Only Here for Compatibility Reasons. Please use HarmonyLib.Priority.First instead.")]
+		[Obsolete("Harmony.Priority.First is Only Here for Compatibility Reasons. Please use HarmonyLib.Priority.First instead. This will be removed in a future update.", true)]
 		public const int First = HarmonyLib.Priority.First;
 	}
 }

--- a/MelonLoader/BackwardsCompatibility/Harmony/Tools/AccessTools.cs
+++ b/MelonLoader/BackwardsCompatibility/Harmony/Tools/AccessTools.cs
@@ -4,7 +4,7 @@ using System.Reflection;
 
 namespace Harmony
 {
-	[Obsolete("Harmony.AccessTools is Only Here for Compatibility Reasons. Please use HarmonyLib.AccessTools instead.")]
+	[Obsolete("Harmony.AccessTools is Only Here for Compatibility Reasons. Please use HarmonyLib.AccessTools instead. This will be removed in a future update.", true)]
 	public static class AccessTools
 	{
 		public static BindingFlags all = HarmonyLib.AccessTools.all;

--- a/MelonLoader/BackwardsCompatibility/Harmony/Tools/Extensions.cs
+++ b/MelonLoader/BackwardsCompatibility/Harmony/Tools/Extensions.cs
@@ -4,35 +4,35 @@ using System.Reflection;
 
 namespace Harmony
 {
-	[Obsolete("Harmony.GeneralExtensions is Only Here for Compatibility Reasons. Please use HarmonyLib.GeneralExtensions instead.")]
+	[Obsolete("Harmony.GeneralExtensions is Only Here for Compatibility Reasons. Please use HarmonyLib.GeneralExtensions instead. This will be removed in a future update.", true)]
 	public static class GeneralExtensions
 	{
-		[Obsolete("Harmony.GeneralExtensions.Join is Only Here for Compatibility Reasons. Please use HarmonyLib.GeneralExtensions.Join instead.")]
+		[Obsolete("Harmony.GeneralExtensions.Join is Only Here for Compatibility Reasons. Please use HarmonyLib.GeneralExtensions.Join instead. This will be removed in a future update.", true)]
 		public static string Join<T>(this IEnumerable<T> enumeration, Func<T, string> converter = null, string delimiter = ", ") => HarmonyLib.GeneralExtensions.Join(enumeration, converter, delimiter);
-		[Obsolete("Harmony.GeneralExtensions.Description is Only Here for Compatibility Reasons. Please use HarmonyLib.GeneralExtensions.Description instead.")]
+		[Obsolete("Harmony.GeneralExtensions.Description is Only Here for Compatibility Reasons. Please use HarmonyLib.GeneralExtensions.Description instead. This will be removed in a future update.", true)]
 		public static string Description(this Type[] parameters) => HarmonyLib.GeneralExtensions.Description(parameters);
-		[Obsolete("Harmony.GeneralExtensions.FullDescription is Only Here for Compatibility Reasons. Please use HarmonyLib.GeneralExtensions.FullDescription instead.")]
+		[Obsolete("Harmony.GeneralExtensions.FullDescription is Only Here for Compatibility Reasons. Please use HarmonyLib.GeneralExtensions.FullDescription instead. This will be removed in a future update.", true)]
 		public static string FullDescription(this MethodBase method) => HarmonyLib.GeneralExtensions.FullDescription(method);
-		[Obsolete("Harmony.GeneralExtensions.Types is Only Here for Compatibility Reasons. Please use HarmonyLib.GeneralExtensions.Types instead.")]
+		[Obsolete("Harmony.GeneralExtensions.Types is Only Here for Compatibility Reasons. Please use HarmonyLib.GeneralExtensions.Types instead. This will be removed in a future update.", true)]
 		public static Type[] Types(this ParameterInfo[] pinfo) => HarmonyLib.GeneralExtensions.Types(pinfo);
-		[Obsolete("Harmony.GeneralExtensions.GetValueSafe is Only Here for Compatibility Reasons. Please use HarmonyLib.GeneralExtensions.GetValueSafe instead.")]
+		[Obsolete("Harmony.GeneralExtensions.GetValueSafe is Only Here for Compatibility Reasons. Please use HarmonyLib.GeneralExtensions.GetValueSafe instead. This will be removed in a future update.", true)]
 		public static T GetValueSafe<S, T>(this Dictionary<S, T> dictionary, S key) => HarmonyLib.GeneralExtensions.GetValueSafe(dictionary, key);
-		[Obsolete("Harmony.GeneralExtensions.GetTypedValue is Only Here for Compatibility Reasons. Please use HarmonyLib.GeneralExtensions.GetTypedValue instead.")]
+		[Obsolete("Harmony.GeneralExtensions.GetTypedValue is Only Here for Compatibility Reasons. Please use HarmonyLib.GeneralExtensions.GetTypedValue instead. This will be removed in a future update.", true)]
 		public static T GetTypedValue<T>(this Dictionary<string, object> dictionary, string key) => HarmonyLib.GeneralExtensions.GetTypedValue<T>(dictionary, key);
 	}
 
-	[Obsolete("Harmony.CollectionExtensions is Only Here for Compatibility Reasons. Please use HarmonyLib.CollectionExtensions instead.")]
+	[Obsolete("Harmony.CollectionExtensions is Only Here for Compatibility Reasons. Please use HarmonyLib.CollectionExtensions instead. This will be removed in a future update.", true)]
 	public static class CollectionExtensions
 	{
-		[Obsolete("Harmony.CollectionExtensions.Do is Only Here for Compatibility Reasons. Please use HarmonyLib.CollectionExtensions.Do instead.")]
+		[Obsolete("Harmony.CollectionExtensions.Do is Only Here for Compatibility Reasons. Please use HarmonyLib.CollectionExtensions.Do instead. This will be removed in a future update.", true)]
 		public static void Do<T>(this IEnumerable<T> sequence, Action<T> action) => HarmonyLib.CollectionExtensions.Do(sequence, action);
-		[Obsolete("Harmony.CollectionExtensions.DoIf is Only Here for Compatibility Reasons. Please use HarmonyLib.CollectionExtensions.DoIf instead.")]
+		[Obsolete("Harmony.CollectionExtensions.DoIf is Only Here for Compatibility Reasons. Please use HarmonyLib.CollectionExtensions.DoIf instead. This will be removed in a future update.", true)]
 		public static void DoIf<T>(this IEnumerable<T> sequence, Func<T, bool> condition, Action<T> action) => HarmonyLib.CollectionExtensions.DoIf(sequence, condition, action);
-		[Obsolete("Harmony.CollectionExtensions.Add is Only Here for Compatibility Reasons. Please use HarmonyLib.CollectionExtensions.Add instead.")]
+		[Obsolete("Harmony.CollectionExtensions.Add is Only Here for Compatibility Reasons. Please use HarmonyLib.CollectionExtensions.Add instead. This will be removed in a future update.", true)]
 		public static IEnumerable<T> Add<T>(this IEnumerable<T> sequence, T item) => HarmonyLib.CollectionExtensions.AddItem(sequence, item);
-		[Obsolete("Harmony.CollectionExtensions.AddRangeToArray is Only Here for Compatibility Reasons. Please use HarmonyLib.CollectionExtensions.AddRangeToArray instead.")]
+		[Obsolete("Harmony.CollectionExtensions.AddRangeToArray is Only Here for Compatibility Reasons. Please use HarmonyLib.CollectionExtensions.AddRangeToArray instead. This will be removed in a future update.", true)]
 		public static T[] AddRangeToArray<T>(this T[] sequence, T[] items) => HarmonyLib.CollectionExtensions.AddRangeToArray(sequence, items);
-		[Obsolete("Harmony.CollectionExtensions.AddToArray is Only Here for Compatibility Reasons. Please use HarmonyLib.CollectionExtensions.AddToArray instead.")]
+		[Obsolete("Harmony.CollectionExtensions.AddToArray is Only Here for Compatibility Reasons. Please use HarmonyLib.CollectionExtensions.AddToArray instead. This will be removed in a future update.", true)]
 		public static T[] AddToArray<T>(this T[] sequence, T item) => HarmonyLib.CollectionExtensions.AddToArray(sequence, item);
 	}
 }

--- a/MelonLoader/BackwardsCompatibility/Harmony/Tools/SymbolExtensions.cs
+++ b/MelonLoader/BackwardsCompatibility/Harmony/Tools/SymbolExtensions.cs
@@ -4,16 +4,16 @@ using System.Reflection;
 
 namespace Harmony
 {
-	[Obsolete("Harmony.SymbolExtensions is Only Here for Compatibility Reasons. Please use HarmonyLib.SymbolExtensions instead.")]
+	[Obsolete("Harmony.SymbolExtensions is Only Here for Compatibility Reasons. Please use HarmonyLib.SymbolExtensions instead. This will be removed in a future update.", true)]
 	public static class SymbolExtensions
 	{
-		[Obsolete("Harmony.SymbolExtensions.GetMethodInfo is Only Here for Compatibility Reasons. Please use HarmonyLib.SymbolExtensions.GetMethodInfo instead.")]
+		[Obsolete("Harmony.SymbolExtensions.GetMethodInfo is Only Here for Compatibility Reasons. Please use HarmonyLib.SymbolExtensions.GetMethodInfo instead. This will be removed in a future update.", true)]
 		public static MethodInfo GetMethodInfo(Expression<Action> expression) => HarmonyLib.SymbolExtensions.GetMethodInfo(expression);
-		[Obsolete("Harmony.SymbolExtensions.GetMethodInfo is Only Here for Compatibility Reasons. Please use HarmonyLib.SymbolExtensions.GetMethodInfo instead.")]
+		[Obsolete("Harmony.SymbolExtensions.GetMethodInfo is Only Here for Compatibility Reasons. Please use HarmonyLib.SymbolExtensions.GetMethodInfo instead. This will be removed in a future update.", true)]
 		public static MethodInfo GetMethodInfo<T>(Expression<Action<T>> expression) => GetMethodInfo((LambdaExpression)expression);
-		[Obsolete("Harmony.SymbolExtensions.GetMethodInfo is Only Here for Compatibility Reasons. Please use HarmonyLib.SymbolExtensions.GetMethodInfo instead.")]
+		[Obsolete("Harmony.SymbolExtensions.GetMethodInfo is Only Here for Compatibility Reasons. Please use HarmonyLib.SymbolExtensions.GetMethodInfo instead. This will be removed in a future update.", true)]
 		public static MethodInfo GetMethodInfo<T, TResult>(Expression<Func<T, TResult>> expression) =>  GetMethodInfo((LambdaExpression)expression);
-		[Obsolete("Harmony.SymbolExtensions.GetMethodInfo is Only Here for Compatibility Reasons. Please use HarmonyLib.SymbolExtensions.GetMethodInfo instead.")]
+		[Obsolete("Harmony.SymbolExtensions.GetMethodInfo is Only Here for Compatibility Reasons. Please use HarmonyLib.SymbolExtensions.GetMethodInfo instead. This will be removed in a future update.", true)]
 		public static MethodInfo GetMethodInfo(LambdaExpression expression) => HarmonyLib.SymbolExtensions.GetMethodInfo(expression);
 	}
 }

--- a/MelonLoader/BackwardsCompatibility/Melon/AssemblyResolveInfo.cs
+++ b/MelonLoader/BackwardsCompatibility/Melon/AssemblyResolveInfo.cs
@@ -2,6 +2,6 @@
 
 namespace MelonLoader.MonoInternals
 {
-    [Obsolete("MelonLoader.MonoInternals.AssemblyResolveInfo is Only Here for Compatibility Reasons. Please use MelonLoader.Resolver.AssemblyResolveInfo instead.")]
+    [Obsolete("MelonLoader.MonoInternals.AssemblyResolveInfo is Only Here for Compatibility Reasons. Please use MelonLoader.Resolver.AssemblyResolveInfo instead. This will be removed in a future update.", true)]
     public class AssemblyResolveInfo : Resolver.AssemblyResolveInfo { }
 }

--- a/MelonLoader/BackwardsCompatibility/Melon/HarmonyShield.cs
+++ b/MelonLoader/BackwardsCompatibility/Melon/HarmonyShield.cs
@@ -2,7 +2,7 @@
 
 namespace Harmony
 {
-    [Obsolete("Harmony.HarmonyShield is Only Here for Compatibility Reasons. Please use MelonLoader.PatchShield instead.")]
+    [Obsolete("Harmony.HarmonyShield is Only Here for Compatibility Reasons. Please use MelonLoader.PatchShield instead. This will be removed in a future update.", true)]
     [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Struct)]
     public class HarmonyShield : MelonLoader.PatchShield { }
 }

--- a/MelonLoader/BackwardsCompatibility/Melon/Imports.cs
+++ b/MelonLoader/BackwardsCompatibility/Melon/Imports.cs
@@ -3,26 +3,26 @@ using MelonLoader.Utils;
 
 namespace MelonLoader
 {
-    [Obsolete("MelonLoader.Imports is Only Here for Compatibility Reasons.")]
+    [Obsolete("MelonLoader.Imports is Only Here for Compatibility Reasons. This will be removed in a future update.", true)]
     public static class Imports
     {
-        [Obsolete("MelonLoader.Imports.GetCompanyName is Only Here for Compatibility Reasons. Please use MelonLoader.InternalUtils.UnityInformationHandler.GameDeveloper instead.")]
+        [Obsolete("MelonLoader.Imports.GetCompanyName is Only Here for Compatibility Reasons. Please use MelonLoader.InternalUtils.UnityInformationHandler.GameDeveloper instead. This will be removed in a future update.", true)]
         public static string GetCompanyName() => InternalUtils.UnityInformationHandler.GameDeveloper;
-        [Obsolete("MelonLoader.Imports.GetProductName is Only Here for Compatibility Reasons. Please use MelonLoader.InternalUtils.UnityInformationHandler.GameName instead.")]
+        [Obsolete("MelonLoader.Imports.GetProductName is Only Here for Compatibility Reasons. Please use MelonLoader.InternalUtils.UnityInformationHandler.GameName instead. This will be removed in a future update.", true)]
         public static string GetProductName() => InternalUtils.UnityInformationHandler.GameName;
-        [Obsolete("MelonLoader.Imports.GetGameDirectory is Only Here for Compatibility Reasons. Please use MelonLoader.Utils.MelonEnvironment.GameRootDirectory instead.")]
+        [Obsolete("MelonLoader.Imports.GetGameDirectory is Only Here for Compatibility Reasons. Please use MelonLoader.Utils.MelonEnvironment.GameRootDirectory instead. This will be removed in a future update.", true)]
         public static string GetGameDirectory() => MelonEnvironment.GameRootDirectory;
-        [Obsolete("MelonLoader.Imports.GetGameDataDirectory is Only Here for Compatibility Reasons. Please use MelonLoader.Utils.MelonEnvironment.UnityGameDataDirectory instead.")]
+        [Obsolete("MelonLoader.Imports.GetGameDataDirectory is Only Here for Compatibility Reasons. Please use MelonLoader.Utils.MelonEnvironment.UnityGameDataDirectory instead. This will be removed in a future update.", true)]
         public static string GetGameDataDirectory() => MelonEnvironment.UnityGameDataDirectory;
-        [Obsolete("MelonLoader.Imports.GetAssemblyDirectory is Only Here for Compatibility Reasons. Please use MelonLoader.Utils.MelonEnvironment.MelonManagedDirectory instead.")]
+        [Obsolete("MelonLoader.Imports.GetAssemblyDirectory is Only Here for Compatibility Reasons. Please use MelonLoader.Utils.MelonEnvironment.MelonManagedDirectory instead. This will be removed in a future update.", true)]
         public static string GetAssemblyDirectory() => MelonEnvironment.MelonManagedDirectory;
-        [Obsolete("MelonLoader.Imports.IsIl2CppGame is Only Here for Compatibility Reasons. Please use MelonLoader.MelonUtils.IsGameIl2Cpp instead.")]
+        [Obsolete("MelonLoader.Imports.IsIl2CppGame is Only Here for Compatibility Reasons. Please use MelonLoader.MelonUtils.IsGameIl2Cpp instead. This will be removed in a future update.", true)]
         public static bool IsIl2CppGame() => MelonUtils.IsGameIl2Cpp();
-        [Obsolete("MelonLoader.Imports.IsDebugMode is Only Here for Compatibility Reasons. Please use MelonLoader.MelonDebug.IsEnabled instead.")]
+        [Obsolete("MelonLoader.Imports.IsDebugMode is Only Here for Compatibility Reasons. Please use MelonLoader.MelonDebug.IsEnabled instead. This will be removed in a future update.", true)]
         public static bool IsDebugMode() => MelonDebug.IsEnabled();
-        [Obsolete("MelonLoader.Imports.Hook is Only Here for Compatibility Reasons. Please use MelonLoader.MelonUtils.NativeHookAttach instead.")]
+        [Obsolete("MelonLoader.Imports.Hook is Only Here for Compatibility Reasons. Please use MelonLoader.MelonUtils.NativeHookAttach instead. This will be removed in a future update.", true)]
         public static void Hook(IntPtr target, IntPtr detour) => MelonUtils.NativeHookAttach(target, detour);
-        [Obsolete("MelonLoader.Imports.Unhook is Only Here for Compatibility Reasons. Please use MelonLoader.MelonUtils.NativeHookDetach instead.")]
+        [Obsolete("MelonLoader.Imports.Unhook is Only Here for Compatibility Reasons. Please use MelonLoader.MelonUtils.NativeHookDetach instead. This will be removed in a future update.", true)]
         public static void Unhook(IntPtr target, IntPtr detour) => MelonUtils.NativeHookDetach(target, detour);
     }
 }

--- a/MelonLoader/BackwardsCompatibility/Melon/Main.cs
+++ b/MelonLoader/BackwardsCompatibility/Melon/Main.cs
@@ -4,18 +4,18 @@ using MelonLoader.Utils;
 
 namespace MelonLoader
 {
-    [Obsolete("MelonLoader.Main is Only Here for Compatibility Reasons.")]
+    [Obsolete("MelonLoader.Main is Only Here for Compatibility Reasons. This will be removed in a future update.", true)]
     public static class Main
     {
-        [Obsolete("MelonLoader.Main.Mods is Only Here for Compatibility Reasons. Please use MelonLoader.MelonHandler.Mods instead.")]
+        [Obsolete("MelonLoader.Main.Mods is Only Here for Compatibility Reasons. Please use MelonLoader.MelonHandler.Mods instead. This will be removed in a future update.", true)]
         public static List<MelonMod> Mods = null;
-        [Obsolete("MelonLoader.Main.Plugins is Only Here for Compatibility Reasons. Please use MelonLoader.MelonHandler.Plugins instead.")]
+        [Obsolete("MelonLoader.Main.Plugins is Only Here for Compatibility Reasons. Please use MelonLoader.MelonHandler.Plugins instead. This will be removed in a future update.", true)]
         public static List<MelonPlugin> Plugins = null;
-        [Obsolete("MelonLoader.Main.IsBoneworks is Only Here for Compatibility Reasons. Please use MelonLoader.MelonUtils.IsBONEWORKS instead.")]
+        [Obsolete("MelonLoader.Main.IsBoneworks is Only Here for Compatibility Reasons. Please use MelonLoader.MelonUtils.IsBONEWORKS instead. This will be removed in a future update.", true)]
         public static bool IsBoneworks = false;
-        [Obsolete("MelonLoader.Main.GetUnityVersion is Only Here for Compatibility Reasons. Please use  MelonLoader.InternalUtils.UnityInformationHandler.EngineVersion instead.")]
+        [Obsolete("MelonLoader.Main.GetUnityVersion is Only Here for Compatibility Reasons. Please use  MelonLoader.InternalUtils.UnityInformationHandler.EngineVersion instead. This will be removed in a future update.", true)]
         public static string GetUnityVersion() => InternalUtils.UnityInformationHandler.EngineVersion.ToStringWithoutType();
-        [Obsolete("MelonLoader.Main.GetUserDataPath is Only Here for Compatibility Reasons. Please use MelonLoader.Utils.MelonEnvironment.UserDataDirectory instead.")]
+        [Obsolete("MelonLoader.Main.GetUserDataPath is Only Here for Compatibility Reasons. Please use MelonLoader.Utils.MelonEnvironment.UserDataDirectory instead. This will be removed in a future update.", true)]
         public static string GetUserDataPath() => MelonEnvironment.UserDataDirectory;
     }
 }

--- a/MelonLoader/BackwardsCompatibility/Melon/MelonConsole.cs
+++ b/MelonLoader/BackwardsCompatibility/Melon/MelonConsole.cs
@@ -2,10 +2,10 @@
 
 namespace MelonLoader
 {
-    [Obsolete("MelonLoader.MelonConsole is Only Here for Compatibility Reasons.")]
+    [Obsolete("MelonLoader.MelonConsole is Only Here for Compatibility Reasons. This will be removed in a future update.", true)]
     public class MelonConsole
     {
-        [Obsolete("MelonLoader.MelonConsole.SetTitle is Only Here for Compatibility Reasons. Please use MelonLoader.MelonUtils.SetConsoleTitle instead.")]
+        [Obsolete("MelonLoader.MelonConsole.SetTitle is Only Here for Compatibility Reasons. Please use MelonLoader.MelonUtils.SetConsoleTitle instead. This will be removed in a future update.", true)]
         public static void SetTitle(string title) => MelonUtils.SetConsoleTitle(title);
     }
 }

--- a/MelonLoader/BackwardsCompatibility/Melon/MelonLoaderBase.cs
+++ b/MelonLoader/BackwardsCompatibility/Melon/MelonLoaderBase.cs
@@ -3,12 +3,12 @@ using MelonLoader.Utils;
 
 namespace MelonLoader
 {
-    [Obsolete("MelonLoader.MelonLoaderBase is Only Here for Compatibility Reasons.")]
+    [Obsolete("MelonLoader.MelonLoaderBase is Only Here for Compatibility Reasons. This will be removed in a future update.", true)]
     public static class MelonLoaderBase
     {
-        [Obsolete("MelonLoader.MelonLoaderBase.UserDataPath is Only Here for Compatibility Reasons. Please use MelonLoader.Utils.MelonEnvironment.UserDataDirectory instead.")]
+        [Obsolete("MelonLoader.MelonLoaderBase.UserDataPath is Only Here for Compatibility Reasons. Please use MelonLoader.Utils.MelonEnvironment.UserDataDirectory instead. This will be removed in a future update.", true)]
         public static string UserDataPath { get => MelonEnvironment.UserDataDirectory; }
-        [Obsolete("MelonLoader.MelonLoaderBase.UnityVersion is Only Here for Compatibility Reasons. Please use MelonLoader.InternalUtils.UnityInformationHandler.EngineVersion instead.")]
+        [Obsolete("MelonLoader.MelonLoaderBase.UnityVersion is Only Here for Compatibility Reasons. Please use MelonLoader.InternalUtils.UnityInformationHandler.EngineVersion instead. This will be removed in a future update.", true)]
         public static string UnityVersion { get => InternalUtils.UnityInformationHandler.EngineVersion.ToStringWithoutType(); }
     }
 }

--- a/MelonLoader/BackwardsCompatibility/Melon/MelonModGameAttribute.cs
+++ b/MelonLoader/BackwardsCompatibility/Melon/MelonModGameAttribute.cs
@@ -2,15 +2,15 @@
 
 namespace MelonLoader
 {
-    [Obsolete("MelonLoader.MelonModGameAttribute is Only Here for Compatibility Reasons. Please use MelonLoader.MelonGame instead.")]
+    [Obsolete("MelonLoader.MelonModGameAttribute is Only Here for Compatibility Reasons. Please use MelonLoader.MelonGame instead. This will be removed in a future update.", true)]
     [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
     public class MelonModGameAttribute : MelonGameAttribute
     {
-        [Obsolete("MelonLoader.MelonModGameAttribute.Developer is Only Here for Compatibility Reasons. Please use MelonLoader.MelonGame.Developer instead.")]
+        [Obsolete("MelonLoader.MelonModGameAttribute.Developer is Only Here for Compatibility Reasons. Please use MelonLoader.MelonGame.Developer instead. This will be removed in a future update.", true)]
         new public string Developer => base.Developer;
-        [Obsolete("MelonLoader.MelonModGameAttribute.GameName is Only Here for Compatibility Reasons. Please use MelonLoader.MelonGame.Name instead.")]
+        [Obsolete("MelonLoader.MelonModGameAttribute.GameName is Only Here for Compatibility Reasons. Please use MelonLoader.MelonGame.Name instead. This will be removed in a future update.", true)]
         public string GameName => Name;
-        [Obsolete("MelonLoader.MelonModGameAttribute is Only Here for Compatibility Reasons. Please use MelonLoader.MelonGame instead.")]
+        [Obsolete("MelonLoader.MelonModGameAttribute is Only Here for Compatibility Reasons. Please use MelonLoader.MelonGame instead. This will be removed in a future update.", true)]
         public MelonModGameAttribute(string developer = null, string gameName = null) : base(developer, gameName) { }
     }
 }

--- a/MelonLoader/BackwardsCompatibility/Melon/MelonModInfoAttribute.cs
+++ b/MelonLoader/BackwardsCompatibility/Melon/MelonModInfoAttribute.cs
@@ -2,21 +2,21 @@
 
 namespace MelonLoader
 {
-    [Obsolete("MelonLoader.MelonPluginInfoAttribute is Only Here for Compatibility Reasons. Please use MelonLoader.MelonInfo instead.")]
+    [Obsolete("MelonLoader.MelonPluginInfoAttribute is Only Here for Compatibility Reasons. Please use MelonLoader.MelonInfo instead. This will be removed in a future update.", true)]
     [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false)]
     public class MelonModInfoAttribute : MelonInfoAttribute
     {
-        [Obsolete("MelonLoader.MelonPluginInfoAttribute.SystemType is Only Here for Compatibility Reasons. Please use MelonLoader.MelonInfo.SystemType instead.")]
+        [Obsolete("MelonLoader.MelonPluginInfoAttribute.SystemType is Only Here for Compatibility Reasons. Please use MelonLoader.MelonInfo.SystemType instead. This will be removed in a future update.", true)]
         new public Type SystemType => base.SystemType;
-        [Obsolete("MelonLoader.MelonPluginInfoAttribute.Name is Only Here for Compatibility Reasons. Please use MelonLoader.MelonInfo.Name instead.")]
+        [Obsolete("MelonLoader.MelonPluginInfoAttribute.Name is Only Here for Compatibility Reasons. Please use MelonLoader.MelonInfo.Name instead. This will be removed in a future update.", true)]
         new public string Name => base.Name;
-        [Obsolete("MelonLoader.MelonPluginInfoAttribute.Version is Only Here for Compatibility Reasons. Please use MelonLoader.MelonInfo.Version instead.")]
+        [Obsolete("MelonLoader.MelonPluginInfoAttribute.Version is Only Here for Compatibility Reasons. Please use MelonLoader.MelonInfo.Version instead. This will be removed in a future update.", true)]
         new public string Version => base.Version;
-        [Obsolete("MelonLoader.MelonPluginInfoAttribute.Author is Only Here for Compatibility Reasons. Please use MelonLoader.MelonInfo.Author instead.")]
+        [Obsolete("MelonLoader.MelonPluginInfoAttribute.Author is Only Here for Compatibility Reasons. Please use MelonLoader.MelonInfo.Author instead. This will be removed in a future update.", true)]
         new public string Author => base.Author;
-        [Obsolete("MelonLoader.MelonPluginInfoAttribute.DownloadLink is Only Here for Compatibility Reasons. Please use MelonLoader.MelonInfo.DownloadLink instead.")]
+        [Obsolete("MelonLoader.MelonPluginInfoAttribute.DownloadLink is Only Here for Compatibility Reasons. Please use MelonLoader.MelonInfo.DownloadLink instead. This will be removed in a future update.", true)]
         new public string DownloadLink => base.DownloadLink;
-        [Obsolete("MelonLoader.MelonPluginInfoAttribute is Only Here for Compatibility Reasons. Please use MelonLoader.MelonInfo instead.")]
+        [Obsolete("MelonLoader.MelonPluginInfoAttribute is Only Here for Compatibility Reasons. Please use MelonLoader.MelonInfo instead. This will be removed in a future update.", true)]
         public MelonModInfoAttribute(Type type, string name, string version, string author, string downloadLink = null) : base(type, name, version, author, downloadLink) { }
     }
 }

--- a/MelonLoader/BackwardsCompatibility/Melon/MelonModLogger.cs
+++ b/MelonLoader/BackwardsCompatibility/Melon/MelonModLogger.cs
@@ -2,6 +2,6 @@
 
 namespace MelonLoader
 {
-    [Obsolete("MelonLoader.MelonModLogger is Only Here for Compatibility Reasons. Please use MelonLoader.MelonLogger instead.")]
+    [Obsolete("MelonLoader.MelonModLogger is Only Here for Compatibility Reasons. Please use MelonLoader.MelonLogger instead. This will be removed in a future update.", true)]
     public class MelonModLogger : MelonLogger { }
 }

--- a/MelonLoader/BackwardsCompatibility/Melon/MelonPluginGameAttribute.cs
+++ b/MelonLoader/BackwardsCompatibility/Melon/MelonPluginGameAttribute.cs
@@ -2,15 +2,15 @@
 
 namespace MelonLoader
 {
-    [Obsolete("MelonLoader.MelonPluginGameAttribute is Only Here for Compatibility Reasons. Please use MelonLoader.MelonGame instead.")]
+    [Obsolete("MelonLoader.MelonPluginGameAttribute is Only Here for Compatibility Reasons. Please use MelonLoader.MelonGame instead. This will be removed in a future update.", true)]
     [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
     public class MelonPluginGameAttribute : MelonGameAttribute
     {
-        [Obsolete("MelonLoader.MelonPluginGameAttribute.Developer is Only Here for Compatibility Reasons. Please use MelonLoader.MelonGame.Developer instead.")]
+        [Obsolete("MelonLoader.MelonPluginGameAttribute.Developer is Only Here for Compatibility Reasons. Please use MelonLoader.MelonGame.Developer instead. This will be removed in a future update.", true)]
         new public string Developer => base.Developer;
-        [Obsolete("MelonLoader.MelonPluginGameAttribute.GameName is Only Here for Compatibility Reasons. Please use MelonLoader.MelonGame.Name instead.")]
+        [Obsolete("MelonLoader.MelonPluginGameAttribute.GameName is Only Here for Compatibility Reasons. Please use MelonLoader.MelonGame.Name instead. This will be removed in a future update.", true)]
         public string GameName => Name;
-        [Obsolete("MelonLoader.MelonPluginGameAttribute is Only Here for Compatibility Reasons. Please use MelonLoader.MelonGame instead.")]
+        [Obsolete("MelonLoader.MelonPluginGameAttribute is Only Here for Compatibility Reasons. Please use MelonLoader.MelonGame instead. This will be removed in a future update.", true)]
         public MelonPluginGameAttribute(string developer = null, string gameName = null) : base(developer, gameName) { }
     }
 }

--- a/MelonLoader/BackwardsCompatibility/Melon/MelonPluginInfoAttribute.cs
+++ b/MelonLoader/BackwardsCompatibility/Melon/MelonPluginInfoAttribute.cs
@@ -2,21 +2,21 @@
 
 namespace MelonLoader
 {
-    [Obsolete("MelonLoader.MelonPluginInfoAttribute is Only Here for Compatibility Reasons. Please use MelonLoader.MelonInfo instead.")]
+    [Obsolete("MelonLoader.MelonPluginInfoAttribute is Only Here for Compatibility Reasons. Please use MelonLoader.MelonInfo instead. This will be removed in a future update.", true)]
     [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false)]
     public class MelonPluginInfoAttribute : MelonInfoAttribute
     {
-        [Obsolete("MelonLoader.MelonPluginInfoAttribute.SystemType is Only Here for Compatibility Reasons. Please use MelonLoader.MelonInfo.SystemType instead.")]
+        [Obsolete("MelonLoader.MelonPluginInfoAttribute.SystemType is Only Here for Compatibility Reasons. Please use MelonLoader.MelonInfo.SystemType instead. This will be removed in a future update.", true)]
         new public Type SystemType => base.SystemType;
-        [Obsolete("MelonLoader.MelonPluginInfoAttribute.Name is Only Here for Compatibility Reasons. Please use MelonLoader.MelonInfo.Name instead.")]
+        [Obsolete("MelonLoader.MelonPluginInfoAttribute.Name is Only Here for Compatibility Reasons. Please use MelonLoader.MelonInfo.Name instead. This will be removed in a future update.", true)]
         new public string Name => base.Name;
-        [Obsolete("MelonLoader.MelonPluginInfoAttribute.Version is Only Here for Compatibility Reasons. Please use MelonLoader.MelonInfo.Version instead.")]
+        [Obsolete("MelonLoader.MelonPluginInfoAttribute.Version is Only Here for Compatibility Reasons. Please use MelonLoader.MelonInfo.Version instead. This will be removed in a future update.", true)]
         new public string Version => base.Version;
-        [Obsolete("MelonLoader.MelonPluginInfoAttribute.Author is Only Here for Compatibility Reasons. Please use MelonLoader.MelonInfo.Author instead.")]
+        [Obsolete("MelonLoader.MelonPluginInfoAttribute.Author is Only Here for Compatibility Reasons. Please use MelonLoader.MelonInfo.Author instead. This will be removed in a future update.", true)]
         new public string Author => base.Author;
-        [Obsolete("MelonLoader.MelonPluginInfoAttribute.DownloadLink is Only Here for Compatibility Reasons. Please use MelonLoader.MelonInfo.DownloadLink instead.")]
+        [Obsolete("MelonLoader.MelonPluginInfoAttribute.DownloadLink is Only Here for Compatibility Reasons. Please use MelonLoader.MelonInfo.DownloadLink instead. This will be removed in a future update.", true)]
         new public string DownloadLink => base.DownloadLink;
-        [Obsolete("MelonLoader.MelonPluginInfoAttribute is Only Here for Compatibility Reasons. Please use MelonLoader.MelonInfo instead.")]
+        [Obsolete("MelonLoader.MelonPluginInfoAttribute is Only Here for Compatibility Reasons. Please use MelonLoader.MelonInfo instead. This will be removed in a future update.", true)]
         public MelonPluginInfoAttribute(Type type, string name, string version, string author, string downloadLink = null) : base(type, name, version, author, downloadLink) { }
     }
 }

--- a/MelonLoader/BackwardsCompatibility/Melon/MelonPrefs.cs
+++ b/MelonLoader/BackwardsCompatibility/Melon/MelonPrefs.cs
@@ -3,22 +3,22 @@ using System.Collections.Generic;
 
 namespace MelonLoader
 {
-    [Obsolete("MelonLoader.MelonPrefs is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences instead.")]
+    [Obsolete("MelonLoader.MelonPrefs is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences instead. This will be removed in a future update.", true)]
     public class MelonPrefs
     {
-        [Obsolete("MelonLoader.MelonPrefs.RegisterCategory is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences.CreateCategory instead.")]
+        [Obsolete("MelonLoader.MelonPrefs.RegisterCategory is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences.CreateCategory instead. This will be removed in a future update.", true)]
         public static void RegisterCategory(string name, string displayText) => MelonPreferences.CreateCategory(name, displayText);
-        [Obsolete("MelonLoader.MelonPrefs.RegisterString is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences.CreateEntry instead.")]
+        [Obsolete("MelonLoader.MelonPrefs.RegisterString is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences.CreateEntry instead. This will be removed in a future update.", true)]
         public static void RegisterString(string section, string name, string defaultValue, string displayText = null, bool hideFromList = false) => MelonPreferences.CreateEntry(section, name, defaultValue, displayText, hideFromList);
-        [Obsolete("MelonLoader.MelonPrefs.RegisterBool is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences.CreateEntry instead.")]
+        [Obsolete("MelonLoader.MelonPrefs.RegisterBool is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences.CreateEntry instead. This will be removed in a future update.", true)]
         public static void RegisterBool(string section, string name, bool defaultValue, string displayText = null, bool hideFromList = false) => MelonPreferences.CreateEntry(section, name, defaultValue, displayText, hideFromList);
-        [Obsolete("MelonLoader.MelonPrefs.RegisterInt is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences.CreateEntry instead.")]
+        [Obsolete("MelonLoader.MelonPrefs.RegisterInt is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences.CreateEntry instead. This will be removed in a future update.", true)]
         public static void RegisterInt(string section, string name, int defaultValue, string displayText = null, bool hideFromList = false) => MelonPreferences.CreateEntry(section, name, defaultValue, displayText, hideFromList);
-        [Obsolete("MelonLoader.MelonPrefs.RegisterFloat is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences.CreateEntry instead.")]
+        [Obsolete("MelonLoader.MelonPrefs.RegisterFloat is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences.CreateEntry instead. This will be removed in a future update.", true)]
         public static void RegisterFloat(string section, string name, float defaultValue, string displayText = null, bool hideFromList = false) => MelonPreferences.CreateEntry(section, name, defaultValue, displayText, hideFromList);
-        [Obsolete("MelonLoader.MelonPrefs.HasKey is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences.HasEntry instead.")]
+        [Obsolete("MelonLoader.MelonPrefs.HasKey is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences.HasEntry instead. This will be removed in a future update.", true)]
         public static bool HasKey(string section, string name) => MelonPreferences.HasEntry(section, name);
-        [Obsolete("MelonLoader.MelonPrefs.GetPreferences is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences.Categories instead.")]
+        [Obsolete("MelonLoader.MelonPrefs.GetPreferences is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences.Categories instead. This will be removed in a future update.", true)]
         public static Dictionary<string, Dictionary<string, MelonPreference>> GetPreferences()
         {
             Dictionary<string, Dictionary<string, MelonPreference>> output = new Dictionary<string, Dictionary<string, MelonPreference>>();
@@ -44,11 +44,11 @@ namespace MelonLoader
             }
             return output;
         }
-        [Obsolete("MelonLoader.MelonPrefs.GetCategoryDisplayName is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences.GetCategoryDisplayName instead.")]
+        [Obsolete("MelonLoader.MelonPrefs.GetCategoryDisplayName is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences.GetCategoryDisplayName instead. This will be removed in a future update.", true)]
         public static string GetCategoryDisplayName(string key) => MelonPreferences.GetCategory(key)?.DisplayName;
-        [Obsolete("MelonLoader.MelonPrefs.SaveConfig is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences.Save instead.")]
+        [Obsolete("MelonLoader.MelonPrefs.SaveConfig is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences.Save instead. This will be removed in a future update.", true)]
         public static void SaveConfig() => MelonPreferences.Save();
-        [Obsolete("MelonLoader.MelonPrefs.GetString is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences.GetEntryString instead.")]
+        [Obsolete("MelonLoader.MelonPrefs.GetString is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences.GetEntryString instead. This will be removed in a future update.", true)]
         public static string GetString(string section, string name)
         {
             MelonPreferences_Category category = MelonPreferences.GetCategory(section);
@@ -59,7 +59,7 @@ namespace MelonLoader
                 return null;
             return entry.GetValueAsString();
         }
-        [Obsolete("MelonLoader.MelonPrefs.SetString is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences.SetEntryString instead.")]
+        [Obsolete("MelonLoader.MelonPrefs.SetString is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences.SetEntryString instead. This will be removed in a future update.", true)]
         public static void SetString(string section, string name, string value)
         {
             MelonPreferences_Category category = MelonPreferences.GetCategory(section);
@@ -87,19 +87,19 @@ namespace MelonLoader
                     break;
             }
         }
-        [Obsolete("MelonLoader.MelonPrefs.GetBool is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences.GetEntryBool instead.")]
+        [Obsolete("MelonLoader.MelonPrefs.GetBool is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences.GetEntryBool instead. This will be removed in a future update.", true)]
         public static bool GetBool(string section, string name) => MelonPreferences.GetEntryValue<bool>(section, name);
-        [Obsolete("MelonLoader.MelonPrefs.SetBool is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences.SetEntryBool instead.")]
+        [Obsolete("MelonLoader.MelonPrefs.SetBool is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences.SetEntryBool instead. This will be removed in a future update.", true)]
         public static void SetBool(string section, string name, bool value) => MelonPreferences.SetEntryValue(section, name, value);
-        [Obsolete("MelonLoader.MelonPrefs.GetInt is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences.GetEntryInt instead.")]
+        [Obsolete("MelonLoader.MelonPrefs.GetInt is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences.GetEntryInt instead. This will be removed in a future update.", true)]
         public static int GetInt(string section, string name) => MelonPreferences.GetEntryValue<int>(section, name);
-        [Obsolete("MelonLoader.MelonPrefs.SetInt is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences.SetEntryInt instead.")]
+        [Obsolete("MelonLoader.MelonPrefs.SetInt is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences.SetEntryInt instead. This will be removed in a future update.", true)]
         public static void SetInt(string section, string name, int value) => MelonPreferences.SetEntryValue(section, name, value);
-        [Obsolete("MelonLoader.MelonPrefs.GetFloat is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences.GetEntryFloat instead.")]
+        [Obsolete("MelonLoader.MelonPrefs.GetFloat is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences.GetEntryFloat instead. This will be removed in a future update.", true)]
         public static float GetFloat(string section, string name) => MelonPreferences.GetEntryValue<float>(section, name);
-        [Obsolete("MelonLoader.MelonPrefs.GetEntryFloat is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences.SetEntryFloat instead.")]
+        [Obsolete("MelonLoader.MelonPrefs.GetEntryFloat is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences.SetEntryFloat instead. This will be removed in a future update.", true)]
         public static void SetFloat(string section, string name, float value) => MelonPreferences.SetEntryValue(section, name, value);
-        [Obsolete("MelonLoader.MelonPrefs.MelonPreferenceType is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences_Entry.TypeEnum instead.")]
+        [Obsolete("MelonLoader.MelonPrefs.MelonPreferenceType is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences_Entry.TypeEnum instead. This will be removed in a future update.", true)]
         public enum MelonPreferenceType
         {
             STRING,
@@ -107,14 +107,14 @@ namespace MelonLoader
             INT,
             FLOAT
         }
-        [Obsolete("MelonLoader.MelonPrefs.MelonPreference is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences_Entry instead.")]
+        [Obsolete("MelonLoader.MelonPrefs.MelonPreference is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences_Entry instead. This will be removed in a future update.", true)]
         public class MelonPreference
         {
-            [Obsolete("MelonLoader.MelonPrefs.MelonPreference.Value is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences_Entry.GetValue instead.")]
+            [Obsolete("MelonLoader.MelonPrefs.MelonPreference.Value is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences_Entry.GetValue instead. This will be removed in a future update.", true)]
             public string Value { get => GetString(Entry.Category.Identifier, Entry.Identifier); set => SetString(Entry.Category.Identifier, Entry.Identifier, value); }
-            [Obsolete("MelonLoader.MelonPrefs.MelonPreference.ValueEdited is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences_Entry.GetValueEdited instead.")]
+            [Obsolete("MelonLoader.MelonPrefs.MelonPreference.ValueEdited is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences_Entry.GetValueEdited instead. This will be removed in a future update.", true)]
             public string ValueEdited { get => GetEditedString(Entry.Category.Identifier, Entry.Identifier); set => SetEditedString(Entry.Category.Identifier, Entry.Identifier, value); }
-            [Obsolete("MelonLoader.MelonPrefs.MelonPreference.Type is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences_Entry.GetReflectedType instead.")]
+            [Obsolete("MelonLoader.MelonPrefs.MelonPreference.Type is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences_Entry.GetReflectedType instead. This will be removed in a future update.", true)]
             public MelonPreferenceType Type
             {
                 get
@@ -133,9 +133,9 @@ namespace MelonLoader
                     return (MelonPreferenceType)4;
                 }
             }
-            [Obsolete("MelonLoader.MelonPrefs.MelonPreference.Hidden is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences_Entry.IsHidden instead.")]
+            [Obsolete("MelonLoader.MelonPrefs.MelonPreference.Hidden is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences_Entry.IsHidden instead. This will be removed in a future update.", true)]
             public bool Hidden { get => Entry.IsHidden; }
-            [Obsolete("MelonLoader.MelonPrefs.MelonPreference.DisplayText is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences_Entry.DisplayName instead.")]
+            [Obsolete("MelonLoader.MelonPrefs.MelonPreference.DisplayText is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences_Entry.DisplayName instead. This will be removed in a future update.", true)]
             public string DisplayText { get => Entry.DisplayName; }
 
             internal MelonPreference(MelonPreferences_Entry entry) => Entry = entry;

--- a/MelonLoader/BackwardsCompatibility/Melon/ModPrefs.cs
+++ b/MelonLoader/BackwardsCompatibility/Melon/ModPrefs.cs
@@ -5,10 +5,10 @@ using System.Linq;
 
 namespace MelonLoader
 {
-    [Obsolete("MelonLoader.ModPrefs is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences instead.")]
+    [Obsolete("MelonLoader.ModPrefs is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences instead. This will be removed in a future update.", true)]
     public class ModPrefs : MelonPrefs
     {
-        [Obsolete("MelonLoader.ModPrefs.GetPrefs is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences instead.")]
+        [Obsolete("MelonLoader.ModPrefs.GetPrefs is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences instead. This will be removed in a future update.", true)]
         public static Dictionary<string, Dictionary<string, PrefDesc>> GetPrefs()
         {
             Dictionary<string, Dictionary<string, PrefDesc>> output = new Dictionary<string, Dictionary<string, PrefDesc>>();
@@ -28,15 +28,15 @@ namespace MelonLoader
             }
             return output;
         }
-        [Obsolete("MelonLoader.ModPrefs.RegisterPrefString is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences.CreateEntry instead.")]
+        [Obsolete("MelonLoader.ModPrefs.RegisterPrefString is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences.CreateEntry instead. This will be removed in a future update.", true)]
         public static void RegisterPrefString(string section, string name, string defaultValue, string displayText = null, bool hideFromList = false) => RegisterString(section, name, defaultValue, displayText, hideFromList);
-        [Obsolete("MelonLoader.ModPrefs.RegisterPrefBool is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences.CreateEntry instead.")]
+        [Obsolete("MelonLoader.ModPrefs.RegisterPrefBool is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences.CreateEntry instead. This will be removed in a future update.", true)]
         public static void RegisterPrefBool(string section, string name, bool defaultValue, string displayText = null, bool hideFromList = false) => RegisterBool(section, name, defaultValue, displayText, hideFromList);
-        [Obsolete("MelonLoader.ModPrefs.RegisterPrefInt is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences.CreateEntry instead.")]
+        [Obsolete("MelonLoader.ModPrefs.RegisterPrefInt is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences.CreateEntry instead. This will be removed in a future update.", true)]
         public static void RegisterPrefInt(string section, string name, int defaultValue, string displayText = null, bool hideFromList = false) => RegisterInt(section, name, defaultValue, displayText, hideFromList);
-        [Obsolete("MelonLoader.ModPrefs.RegisterPrefFloat is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences.CreateEntry instead.")]
+        [Obsolete("MelonLoader.ModPrefs.RegisterPrefFloat is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences.CreateEntry instead. This will be removed in a future update.", true)]
         public static void RegisterPrefFloat(string section, string name, float defaultValue, string displayText = null, bool hideFromList = false) => RegisterFloat(section, name, defaultValue, displayText, hideFromList);
-        [Obsolete("MelonLoader.ModPrefs.PrefType is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences_Entry.TypeEnum instead.")]
+        [Obsolete("MelonLoader.ModPrefs.PrefType is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences_Entry.TypeEnum instead. This will be removed in a future update.", true)]
         public enum PrefType
         {
             STRING,
@@ -44,14 +44,14 @@ namespace MelonLoader
             INT,
             FLOAT
         }
-        [Obsolete("MelonLoader.ModPrefs.PrefDesc is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences_Entry instead.")]
+        [Obsolete("MelonLoader.ModPrefs.PrefDesc is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences_Entry instead. This will be removed in a future update.", true)]
         public class PrefDesc : MelonPreference
         {
-            [Obsolete("MelonLoader.ModPrefs.PrefDesc.Type is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences_Entry.Type instead.")]
+            [Obsolete("MelonLoader.ModPrefs.PrefDesc.Type is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences_Entry.Type instead. This will be removed in a future update.", true)]
             public PrefType Type { get => (PrefType)base.Type; }
-            [Obsolete("MelonLoader.ModPrefs.PrefDesc is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences_Entry instead.")]
+            [Obsolete("MelonLoader.ModPrefs.PrefDesc is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences_Entry instead. This will be removed in a future update.", true)]
             public PrefDesc(MelonPreferences_Entry entry) : base(entry) { }
-            [Obsolete("MelonLoader.ModPrefs.PrefDesc is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences_Entry instead.")]
+            [Obsolete("MelonLoader.ModPrefs.PrefDesc is Only Here for Compatibility Reasons. Please use MelonLoader.MelonPreferences_Entry instead. This will be removed in a future update.", true)]
             public PrefDesc(MelonPreference pref) : base(pref) { }
         }
     }

--- a/MelonLoader/BackwardsCompatibility/Melon/MonoLibrary.cs
+++ b/MelonLoader/BackwardsCompatibility/Melon/MonoLibrary.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace MelonLoader.MonoInternals
 {
-    [Obsolete("MelonLoader.MonoInternals.MonoLibrary is Only Here for Compatibility Reasons. Please use MelonLoader.Utils.MonoLibrary instead.")]
+    [Obsolete("MelonLoader.MonoInternals.MonoLibrary is Only Here for Compatibility Reasons. Please use MelonLoader.Utils.MonoLibrary instead. This will be removed in a future update.", true)]
     public class MonoLibrary : Utils.MonoLibrary { }
 }
 

--- a/MelonLoader/BackwardsCompatibility/Melon/MonoResolveManager.cs
+++ b/MelonLoader/BackwardsCompatibility/Melon/MonoResolveManager.cs
@@ -3,36 +3,36 @@ using System.Reflection;
 
 namespace MelonLoader.MonoInternals
 {
-    [Obsolete("MelonLoader.MonoInternals.MonoResolveManager is Only Here for Compatibility Reasons. Please use MelonLoader.Resolver.MelonAssemblyResolver instead.")]
+    [Obsolete("MelonLoader.MonoInternals.MonoResolveManager is Only Here for Compatibility Reasons. Please use MelonLoader.Resolver.MelonAssemblyResolver instead. This will be removed in a future update.", true)]
     public static class MonoResolveManager
     {
-        [Obsolete("MelonLoader.MonoInternals.MonoResolveManager.AddSearchDirectory is Only Here for Compatibility Reasons. Please use MelonLoader.Resolver.MelonAssemblyResolver.AddSearchDirectory instead.")]
+        [Obsolete("MelonLoader.MonoInternals.MonoResolveManager.AddSearchDirectory is Only Here for Compatibility Reasons. Please use MelonLoader.Resolver.MelonAssemblyResolver.AddSearchDirectory instead. This will be removed in a future update.", true)]
         public static void AddSearchDirectory(string path, int priority = 0)
             => Resolver.SearchDirectoryManager.Add(path, priority);
 
-        [Obsolete("MelonLoader.MonoInternals.MonoResolveManager.RemoveSearchDirectory is Only Here for Compatibility Reasons. Please use MelonLoader.Resolver.MelonAssemblyResolver.RemoveSearchDirectory instead.")]
+        [Obsolete("MelonLoader.MonoInternals.MonoResolveManager.RemoveSearchDirectory is Only Here for Compatibility Reasons. Please use MelonLoader.Resolver.MelonAssemblyResolver.RemoveSearchDirectory instead. This will be removed in a future update.", true)]
         public static void RemoveSearchDirectory(string path)
             => Resolver.SearchDirectoryManager.Remove(path);
 
-        [Obsolete("MelonLoader.MonoInternals.MonoResolveManager.OnAssemblyLoadHandler is Only Here for Compatibility Reasons. Please use MelonLoader.Resolver.MelonAssemblyResolver.dOnAssemblyLoad instead.")]
+        [Obsolete("MelonLoader.MonoInternals.MonoResolveManager.OnAssemblyLoadHandler is Only Here for Compatibility Reasons. Please use MelonLoader.Resolver.MelonAssemblyResolver.dOnAssemblyLoad instead. This will be removed in a future update.", true)]
         public delegate void OnAssemblyLoadHandler(Assembly assembly);
-        [Obsolete("MelonLoader.MonoInternals.MonoResolveManager.OnAssemblyLoad is Only Here for Compatibility Reasons. Please use MelonLoader.Resolver.MelonAssemblyResolver.OnAssemblyLoad instead.")]
+        [Obsolete("MelonLoader.MonoInternals.MonoResolveManager.OnAssemblyLoad is Only Here for Compatibility Reasons. Please use MelonLoader.Resolver.MelonAssemblyResolver.OnAssemblyLoad instead. This will be removed in a future update.", true)]
         public static event OnAssemblyLoadHandler OnAssemblyLoad;
         internal static void SafeInvoke_OnAssemblyLoad(Assembly assembly)
             => OnAssemblyLoad?.Invoke(assembly);
 
-        [Obsolete("MelonLoader.MonoInternals.MonoResolveManager.OnAssemblyResolveHandler is Only Here for Compatibility Reasons. Please use MelonLoader.Resolver.MelonAssemblyResolver.dOnAssemblyResolve instead.")]
+        [Obsolete("MelonLoader.MonoInternals.MonoResolveManager.OnAssemblyResolveHandler is Only Here for Compatibility Reasons. Please use MelonLoader.Resolver.MelonAssemblyResolver.dOnAssemblyResolve instead. This will be removed in a future update.", true)]
         public delegate Assembly OnAssemblyResolveHandler(string name, Version version);
-        [Obsolete("MelonLoader.MonoInternals.MonoResolveManager.OnAssemblyLoad is Only Here for Compatibility Reasons. Please use MelonLoader.Resolver.MelonAssemblyResolver.OnAssemblyLoad instead.")]
+        [Obsolete("MelonLoader.MonoInternals.MonoResolveManager.OnAssemblyLoad is Only Here for Compatibility Reasons. Please use MelonLoader.Resolver.MelonAssemblyResolver.OnAssemblyLoad instead. This will be removed in a future update.", true)]
         public static event OnAssemblyResolveHandler OnAssemblyResolve;
         internal static Assembly SafeInvoke_OnAssemblyResolve(string name, Version version)
             => OnAssemblyResolve?.Invoke(name, version);
 
-        [Obsolete("MelonLoader.MonoInternals.MonoResolveManager.GetAssemblyResolveInfo is Only Here for Compatibility Reasons. Please use MelonLoader.Resolver.MelonAssemblyResolver.GetAssemblyResolveInfo instead.")]
+        [Obsolete("MelonLoader.MonoInternals.MonoResolveManager.GetAssemblyResolveInfo is Only Here for Compatibility Reasons. Please use MelonLoader.Resolver.MelonAssemblyResolver.GetAssemblyResolveInfo instead. This will be removed in a future update.", true)]
         public static AssemblyResolveInfo GetAssemblyResolveInfo(string name)
             => (AssemblyResolveInfo)Resolver.AssemblyManager.GetInfo(name);
 
-        [Obsolete("MelonLoader.MonoInternals.MonoResolveManager.LoadInfoFromAssembly is Only Here for Compatibility Reasons. Please use MelonLoader.Resolver.MelonAssemblyResolver.LoadInfoFromAssembly instead.")]
+        [Obsolete("MelonLoader.MonoInternals.MonoResolveManager.LoadInfoFromAssembly is Only Here for Compatibility Reasons. Please use MelonLoader.Resolver.MelonAssemblyResolver.LoadInfoFromAssembly instead. This will be removed in a future update.", true)]
         public static void LoadInfoFromAssembly(Assembly assembly)
             => Resolver.AssemblyManager.LoadInfo(assembly);
     }

--- a/MelonLoader/BackwardsCompatibility/Melon/bHaptics.cs
+++ b/MelonLoader/BackwardsCompatibility/Melon/bHaptics.cs
@@ -9,24 +9,24 @@ namespace MelonLoader
     {
         public static bool WasError { get => false; }
 
-        [Obsolete("MelonLoader.bHaptics.IsPlaying is Only Here for Compatibility Reasons. Please use bHapticsLib.bHapticsManager.IsPlayingAny instead.")]
+        [Obsolete("MelonLoader.bHaptics.IsPlaying is Only Here for Compatibility Reasons. Please use bHapticsLib.bHapticsManager.IsPlayingAny instead. This will be removed in a future update.", true)]
         public static bool IsPlaying()
             => bHapticsLib.bHapticsManager.IsPlayingAny();
-        [Obsolete("MelonLoader.bHaptics.IsPlaying(string) is Only Here for Compatibility Reasons. Please use bHapticsLib.bHapticsManager.IsPlaying instead.")]
+        [Obsolete("MelonLoader.bHaptics.IsPlaying(string) is Only Here for Compatibility Reasons. Please use bHapticsLib.bHapticsManager.IsPlaying instead. This will be removed in a future update.", true)]
         public static bool IsPlaying(string key)
             => bHapticsLib.bHapticsManager.IsPlaying(key);
 
-        [Obsolete("MelonLoader.bHaptics.IsDeviceConnected(DeviceType, bool) is Only Here for Compatibility Reasons. Please use bHapticsLib.bHapticsManager.IsDeviceConnected instead.")]
+        [Obsolete("MelonLoader.bHaptics.IsDeviceConnected(DeviceType, bool) is Only Here for Compatibility Reasons. Please use bHapticsLib.bHapticsManager.IsDeviceConnected instead. This will be removed in a future update.", true)]
         public static bool IsDeviceConnected(DeviceType type, bool isLeft = true) => IsDeviceConnected(DeviceTypeToPositionType(type, isLeft));
-        [Obsolete("MelonLoader.bHaptics.IsDeviceConnected(PositionType) is Only Here for Compatibility Reasons. Please use bHapticsLib.bHapticsManager.IsDeviceConnected instead.")]
+        [Obsolete("MelonLoader.bHaptics.IsDeviceConnected(PositionType) is Only Here for Compatibility Reasons. Please use bHapticsLib.bHapticsManager.IsDeviceConnected instead. This will be removed in a future update.", true)]
         public static bool IsDeviceConnected(PositionType type)
             => bHapticsLib.bHapticsManager.IsDeviceConnected(PositionTypeToPositionID(type));
 
-        [Obsolete("MelonLoader.bHaptics.IsFeedbackRegistered is Only Here for Compatibility Reasons. Please use bHapticsLib.bHapticsManager.IsPatternRegistered instead.")]
+        [Obsolete("MelonLoader.bHaptics.IsFeedbackRegistered is Only Here for Compatibility Reasons. Please use bHapticsLib.bHapticsManager.IsPatternRegistered instead. This will be removed in a future update.", true)]
         public static bool IsFeedbackRegistered(string key)
             => bHapticsLib.bHapticsManager.IsPatternRegistered(key);
 
-        [Obsolete("MelonLoader.bHaptics.RegisterFeedback is Only Here for Compatibility Reasons. Please use bHapticsLib.bHapticsManager.RegisterPatternFromJson instead.")]
+        [Obsolete("MelonLoader.bHaptics.RegisterFeedback is Only Here for Compatibility Reasons. Please use bHapticsLib.bHapticsManager.RegisterPatternFromJson instead. This will be removed in a future update.", true)]
         public static void RegisterFeedback(string key, string tactFileStr)
         {
             TinyJSON.ProxyArray proxyArray = new TinyJSON.ProxyArray();
@@ -34,56 +34,56 @@ namespace MelonLoader
             bHapticsLib.bHapticsManager.RegisterPatternFromJson(key, TinyJSON.Encoder.Encode(proxyArray));
         }
 
-        [Obsolete("MelonLoader.bHaptics.RegisterFeedbackFromTactFile is Only Here for Compatibility Reasons. Please use bHapticsLib.bHapticsManager.RegisterPatternFromJson instead.")]
+        [Obsolete("MelonLoader.bHaptics.RegisterFeedbackFromTactFile is Only Here for Compatibility Reasons. Please use bHapticsLib.bHapticsManager.RegisterPatternFromJson instead. This will be removed in a future update.", true)]
         public static void RegisterFeedbackFromTactFile(string key, string tactFileStr)
             => bHapticsLib.bHapticsManager.RegisterPatternFromJson(key, tactFileStr);
-        [Obsolete("MelonLoader.bHaptics.RegisterFeedbackFromTactFileReflected is Only Here for Compatibility Reasons. Please use bHapticsLib.bHapticsManager.RegisterPatternSwappedFromJson instead.")]
+        [Obsolete("MelonLoader.bHaptics.RegisterFeedbackFromTactFileReflected is Only Here for Compatibility Reasons. Please use bHapticsLib.bHapticsManager.RegisterPatternSwappedFromJson instead. This will be removed in a future update.", true)]
         public static void RegisterFeedbackFromTactFileReflected(string key, string tactFileStr)
             => bHapticsLib.bHapticsManager.RegisterPatternSwappedFromJson(key, tactFileStr);
 
-        [Obsolete("MelonLoader.bHaptics.SubmitRegistered is Only Here for Compatibility Reasons. Please use bHapticsLib.bHapticsManager.PlayRegistered instead.")]
+        [Obsolete("MelonLoader.bHaptics.SubmitRegistered is Only Here for Compatibility Reasons. Please use bHapticsLib.bHapticsManager.PlayRegistered instead. This will be removed in a future update.", true)]
         public static void SubmitRegistered(string key)
             => bHapticsLib.bHapticsManager.PlayRegistered(key);
-        [Obsolete("MelonLoader.bHaptics.SubmitRegistered is Only Here for Compatibility Reasons. Please use bHapticsLib.bHapticsManager.PlayRegistered instead.")]
+        [Obsolete("MelonLoader.bHaptics.SubmitRegistered is Only Here for Compatibility Reasons. Please use bHapticsLib.bHapticsManager.PlayRegistered instead. This will be removed in a future update.", true)]
         public static void SubmitRegistered(string key, int startTimeMillis)
             => bHapticsLib.bHapticsManager.PlayRegistered(key, startTimeMillis);
-        [Obsolete("MelonLoader.bHaptics.SubmitRegistered is Only Here for Compatibility Reasons. Please use bHapticsLib.bHapticsManager.PlayRegistered instead.")]
+        [Obsolete("MelonLoader.bHaptics.SubmitRegistered is Only Here for Compatibility Reasons. Please use bHapticsLib.bHapticsManager.PlayRegistered instead. This will be removed in a future update.", true)]
         public static void SubmitRegistered(string key, string altKey, ScaleOption option)
             => bHapticsLib.bHapticsManager.PlayRegistered(key, altKey,
                 new bHapticsLib.ScaleOption { Duration = option.Duration, Intensity = option.Intensity });
-        [Obsolete("MelonLoader.bHaptics.SubmitRegistered is Only Here for Compatibility Reasons. Please use bHapticsLib.bHapticsManager.PlayRegistered instead.")]
+        [Obsolete("MelonLoader.bHaptics.SubmitRegistered is Only Here for Compatibility Reasons. Please use bHapticsLib.bHapticsManager.PlayRegistered instead. This will be removed in a future update.", true)]
         public static void SubmitRegistered(string key, string altKey, ScaleOption sOption, RotationOption rOption)
             => bHapticsLib.bHapticsManager.PlayRegistered(key, altKey,
                 new bHapticsLib.ScaleOption { Duration = sOption.Duration, Intensity = sOption.Intensity }, 
                 new bHapticsLib.RotationOption { OffsetAngleX = rOption.OffsetX, OffsetY = rOption.OffsetY });
 
-        [Obsolete("MelonLoader.bHaptics.TurnOff is Only Here for Compatibility Reasons. Please use bHapticsLib.bHapticsManager.StopPlayingAll instead.")]
+        [Obsolete("MelonLoader.bHaptics.TurnOff is Only Here for Compatibility Reasons. Please use bHapticsLib.bHapticsManager.StopPlayingAll instead. This will be removed in a future update.", true)]
         public static void TurnOff()
             => bHapticsLib.bHapticsManager.StopPlayingAll();
-        [Obsolete("MelonLoader.bHaptics.TurnOff(string) is Only Here for Compatibility Reasons. Please use bHapticsLib.bHapticsManager.StopPlaying instead.")]
+        [Obsolete("MelonLoader.bHaptics.TurnOff(string) is Only Here for Compatibility Reasons. Please use bHapticsLib.bHapticsManager.StopPlaying instead. This will be removed in a future update.", true)]
         public static void TurnOff(string key)
             => bHapticsLib.bHapticsManager.StopPlaying(key);
 
-        [Obsolete("MelonLoader.bHaptics.Submit is Only Here for Compatibility Reasons. Please use bHapticsLib.bHapticsManager.Play instead.")]
+        [Obsolete("MelonLoader.bHaptics.Submit is Only Here for Compatibility Reasons. Please use bHapticsLib.bHapticsManager.Play instead. This will be removed in a future update.", true)]
         public static void Submit(string key, DeviceType type, bool isLeft, byte[] bytes, int durationMillis) => Submit(key, DeviceTypeToPositionType(type, isLeft), bytes, durationMillis);
-        [Obsolete("MelonLoader.bHaptics.Submit is Only Here for Compatibility Reasons. Please use bHapticsLib.bHapticsManager.Play instead.")]
+        [Obsolete("MelonLoader.bHaptics.Submit is Only Here for Compatibility Reasons. Please use bHapticsLib.bHapticsManager.Play instead. This will be removed in a future update.", true)]
         public static void Submit(string key, PositionType position, byte[] bytes, int durationMillis)
             => bHapticsLib.bHapticsManager.Play(key, durationMillis, PositionTypeToPositionID(position), bytes);
 
-
+        [Obsolete]
         private static Converter<DotPoint, bHapticsLib.DotPoint> DotPointConverter = new Converter<DotPoint, bHapticsLib.DotPoint>((x) 
             => new bHapticsLib.DotPoint 
             {
                 Index = x.Index,
                 Intensity = x.Intensity 
             });
-        [Obsolete("MelonLoader.bHaptics.Submit is Only Here for Compatibility Reasons. Please use bHapticsLib.bHapticsManager.Play instead.")]
+        [Obsolete("MelonLoader.bHaptics.Submit is Only Here for Compatibility Reasons. Please use bHapticsLib.bHapticsManager.Play instead. This will be removed in a future update.", true)]
         public static void Submit(string key, DeviceType type, bool isLeft, List<DotPoint> points, int durationMillis) => Submit(key, DeviceTypeToPositionType(type, isLeft), points, durationMillis);
-        [Obsolete("MelonLoader.bHaptics.Submit is Only Here for Compatibility Reasons. Please use bHapticsLib.bHapticsManager.Play instead.")]
+        [Obsolete("MelonLoader.bHaptics.Submit is Only Here for Compatibility Reasons. Please use bHapticsLib.bHapticsManager.Play instead. This will be removed in a future update.", true)]
         public static void Submit(string key, PositionType position, List<DotPoint> points, int durationMillis)
             => bHapticsLib.bHapticsManager.Play(key, durationMillis, PositionTypeToPositionID(position), points.ConvertAll(DotPointConverter));
 
-
+        [Obsolete]
         private static Converter<PathPoint, bHapticsLib.PathPoint> PathPointConverter = new Converter<PathPoint, bHapticsLib.PathPoint>((x)
             => new bHapticsLib.PathPoint
             {
@@ -92,19 +92,19 @@ namespace MelonLoader
                 Intensity = x.Intensity,
                 MotorCount = x.MotorCount
             });
-        [Obsolete("MelonLoader.bHaptics.Submit is Only Here for Compatibility Reasons. Please use bHapticsLib.bHapticsManager.Play instead.")]
+        [Obsolete("MelonLoader.bHaptics.Submit is Only Here for Compatibility Reasons. Please use bHapticsLib.bHapticsManager.Play instead. This will be removed in a future update.", true)]
         public static void Submit(string key, DeviceType type, bool isLeft, List<PathPoint> points, int durationMillis) => Submit(key, DeviceTypeToPositionType(type, isLeft), points, durationMillis);
-        [Obsolete("MelonLoader.bHaptics.Submit is Only Here for Compatibility Reasons. Please use bHapticsLib.bHapticsManager.Play instead.")]
+        [Obsolete("MelonLoader.bHaptics.Submit is Only Here for Compatibility Reasons. Please use bHapticsLib.bHapticsManager.Play instead. This will be removed in a future update.", true)]
         public static void Submit(string key, PositionType position, List<PathPoint> points, int durationMillis)
             => bHapticsLib.bHapticsManager.Play(key, durationMillis, PositionTypeToPositionID(position), (bHapticsLib.DotPoint[])null, points.ConvertAll(PathPointConverter));
 
-        [Obsolete("MelonLoader.bHaptics.GetCurrentFeedbackStatus is Only Here for Compatibility Reasons. Please use bHapticsLib.bHapticsManager.GetDeviceStatus instead.")]
+        [Obsolete("MelonLoader.bHaptics.GetCurrentFeedbackStatus is Only Here for Compatibility Reasons. Please use bHapticsLib.bHapticsManager.GetDeviceStatus instead. This will be removed in a future update.", true)]
         public static FeedbackStatus GetCurrentFeedbackStatus(DeviceType type, bool isLeft = true) => GetCurrentFeedbackStatus(DeviceTypeToPositionType(type, isLeft));
-        [Obsolete("MelonLoader.bHaptics.GetCurrentFeedbackStatus is Only Here for Compatibility Reasons. Please use bHapticsLib.bHapticsManager.GetDeviceStatus instead.")]
+        [Obsolete("MelonLoader.bHaptics.GetCurrentFeedbackStatus is Only Here for Compatibility Reasons. Please use bHapticsLib.bHapticsManager.GetDeviceStatus instead. This will be removed in a future update.", true)]
         public static FeedbackStatus GetCurrentFeedbackStatus(PositionType pos)
             => new FeedbackStatus { values = bHapticsLib.bHapticsManager.GetDeviceStatus(PositionTypeToPositionID(pos)) };
 
-        [Obsolete("MelonLoader.bHaptics.DeviceTypeToPositionType is Only Here for Compatibility Reasons.")]
+        [Obsolete("MelonLoader.bHaptics.DeviceTypeToPositionType is Only Here for Compatibility Reasons. This will be removed in a future update.", true)]
         public static PositionType DeviceTypeToPositionType(DeviceType pos, bool isLeft = true)
         => (pos) switch
         {
@@ -116,7 +116,7 @@ namespace MelonLoader
             _ => PositionType.Head
         };
 
-        [Obsolete("MelonLoader.bHaptics.DeviceType is Only Here for Compatibility Reasons.")]
+        [Obsolete("MelonLoader.bHaptics.DeviceType is Only Here for Compatibility Reasons. This will be removed in a future update.", true)]
         public enum DeviceType
         {
             None = 0,
@@ -127,7 +127,7 @@ namespace MelonLoader
             Tactosy_feet = 5
         }
 
-        [Obsolete("MelonLoader.bHaptics.PositionType is Only Here for Compatibility Reasons. Please use bHapticsLib.PositionID instead.")]
+        [Obsolete("MelonLoader.bHaptics.PositionType is Only Here for Compatibility Reasons. Please use bHapticsLib.PositionID instead. This will be removed in a future update.", true)]
         public enum PositionType
         {
             All = 0,
@@ -152,7 +152,7 @@ namespace MelonLoader
             Custom4 = 254
         }
 
-        [Obsolete("MelonLoader.bHaptics.RotationOption is Only Here for Compatibility Reasons. Please use bHapticsLib.RotationOption instead.")]
+        [Obsolete("MelonLoader.bHaptics.RotationOption is Only Here for Compatibility Reasons. Please use bHapticsLib.RotationOption instead. This will be removed in a future update.", true)]
         public class RotationOption
         {
             public float OffsetX, OffsetY;
@@ -167,7 +167,7 @@ namespace MelonLoader
                        ", OffsetY=" + OffsetY.ToString() + " }";
         }
 
-        [Obsolete("MelonLoader.bHaptics.ScaleOption is Only Here for Compatibility Reasons. Please use bHapticsLib.ScaleOption instead.")]
+        [Obsolete("MelonLoader.bHaptics.ScaleOption is Only Here for Compatibility Reasons. Please use bHapticsLib.ScaleOption instead. This will be removed in a future update.", true)]
         public class ScaleOption
         {
             public float Intensity, Duration;
@@ -182,7 +182,7 @@ namespace MelonLoader
                        ", Duration=" + Duration.ToString() + " }";
         }
 
-        [Obsolete("MelonLoader.bHaptics.DotPoint is Only Here for Compatibility Reasons. Please use bHapticsLib.DotPoint instead.")]
+        [Obsolete("MelonLoader.bHaptics.DotPoint is Only Here for Compatibility Reasons. Please use bHapticsLib.DotPoint instead. This will be removed in a future update.", true)]
         public class DotPoint
         {
             public int Index, Intensity;
@@ -199,7 +199,7 @@ namespace MelonLoader
                        ", Intensity=" + Intensity.ToString() + " }";
         }
 
-        [Obsolete("MelonLoader.bHaptics.PathPoint is Only Here for Compatibility Reasons. Please use bHapticsLib.PathPoint instead.")]
+        [Obsolete("MelonLoader.bHaptics.PathPoint is Only Here for Compatibility Reasons. Please use bHapticsLib.PathPoint instead. This will be removed in a future update.", true)]
         [StructLayout(LayoutKind.Sequential)]
         public struct PathPoint
         {
@@ -221,7 +221,7 @@ namespace MelonLoader
                        ", Intensity=" + Intensity.ToString() + " }";
         }
 
-        [Obsolete("MelonLoader.bHaptics.FeedbackStatus is Only Here for Compatibility Reasons.")]
+        [Obsolete("MelonLoader.bHaptics.FeedbackStatus is Only Here for Compatibility Reasons. This will be removed in a future update.", true)]
         [StructLayout(LayoutKind.Sequential)]
         public struct FeedbackStatus
         {
@@ -229,6 +229,7 @@ namespace MelonLoader
             public int[] values;
         };
 
+        [Obsolete]
         private static bHapticsLib.PositionID PositionTypeToPositionID(PositionType pos)
             => (pos) switch
             {

--- a/MelonLoader/InternalUtils/BootstrapInterop.cs
+++ b/MelonLoader/InternalUtils/BootstrapInterop.cs
@@ -15,14 +15,9 @@ internal static unsafe class BootstrapInterop
 
     internal static void SetDefaultConsoleTitleWithGameName(string gameName, string gameVersion = null)
     {
-        if (LoaderConfig.Current.Console.DontSetTitle || !Library.IsConsoleOpen())
-            return;
-
         var versionStr = $"{Core.GetVersionString()} - {gameName} {gameVersion ?? ""}";
 
-        // Setting the title might not work on .net 2.0. In WTTG 2 it's present in mscorlib, but the resolver can't find it for whatever reason.
-        // Using reflection to avoid resolver errors
-        HarmonyLib.AccessTools.Property(typeof(Console), "Title")?.SetValue(null, versionStr, null);
+        MelonUtils.SetConsoleTitle(versionStr);
     }
 
 #if WINDOWS

--- a/MelonLoader/MelonLaunchOptions.cs
+++ b/MelonLoader/MelonLaunchOptions.cs
@@ -97,10 +97,10 @@ namespace MelonLoader
 
         #region Obsolete
 
-        [Obsolete("Use LoaderConfig.Current.Loader instead.")]
+        [Obsolete("Use LoaderConfig.Current.Loader instead. This will be removed in a future update.", true)]
         public static class Core
         {
-            [Obsolete("This option isn't used anymore.")]
+            [Obsolete("This option isn't used anymore. This will be removed in a future update.", true)]
             public enum LoadModeEnum
             {
                 NORMAL,
@@ -108,32 +108,32 @@ namespace MelonLoader
                 BOTH
             }
 
-            [Obsolete("This option isn't used anymore. It will always return NORMAL.")]
+            [Obsolete("This option isn't used anymore. It will always return NORMAL. This will be removed in a future update.", true)]
             public static LoadModeEnum LoadMode_Plugins => LoadModeEnum.NORMAL;
 
-            [Obsolete("This option isn't used anymore. It will always return NORMAL.")]
+            [Obsolete("This option isn't used anymore. It will always return NORMAL. This will be removed in a future update.", true)]
             public static LoadModeEnum LoadMode_Mods => LoadModeEnum.NORMAL;
 
-            [Obsolete("Use LoaderConfig.Current.Loader.ForceQuit instead.")]
+            [Obsolete("Use LoaderConfig.Current.Loader.ForceQuit instead. This will be removed in a future update.", true)]
             public static bool QuitFix => LoaderConfig.Current.Loader.ForceQuit;
 
-            [Obsolete("Use LoaderConfig.Current.Loader.DisableStartScreen instead.")]
+            [Obsolete("Use LoaderConfig.Current.Loader.DisableStartScreen instead. This will be removed in a future update.", true)]
             public static bool StartScreen => !LoaderConfig.Current.Loader.DisableStartScreen;
 
-            [Obsolete("Use LoaderConfig.Current.UnityEngine.VersionOverride instead.")]
+            [Obsolete("Use LoaderConfig.Current.UnityEngine.VersionOverride instead. This will be removed in a future update.", true)]
             public static string UnityVersion => LoaderConfig.Current.UnityEngine.VersionOverride;
 
-            [Obsolete("Use LoaderConfig.Current.Loader.DebugMode instead.")]
+            [Obsolete("Use LoaderConfig.Current.Loader.DebugMode instead. This will be removed in a future update.", true)]
             public static bool IsDebug => LoaderConfig.Current.Loader.DebugMode;
 
-            [Obsolete("Use LoaderConfig.Current.Loader.LaunchDebugger instead.")]
+            [Obsolete("Use LoaderConfig.Current.Loader.LaunchDebugger instead. This will be removed in a future update.", true)]
             public static bool UserWantsDebugger => LoaderConfig.Current.Loader.LaunchDebugger;
         }
 
-        [Obsolete("Use LoaderConfig.Current.Console instead.")]
+        [Obsolete("Use LoaderConfig.Current.Console instead. This will be removed in a future update.", true)]
         public static class Console
         {
-            [Obsolete("Use LoaderConfig.CoreConfig.LoaderTheme instead.")]
+            [Obsolete("Use LoaderConfig.CoreConfig.LoaderTheme instead. This will be removed in a future update.", true)]
             public enum DisplayMode
             {
                 NORMAL,
@@ -143,61 +143,61 @@ namespace MelonLoader
                 LEMON
             };
 
-            [Obsolete("Use LoaderConfig.Current.Loader.Theme instead.")]
+            [Obsolete("Use LoaderConfig.Current.Loader.Theme instead. This will be removed in a future update.", true)]
             public static DisplayMode Mode => (DisplayMode)LoaderConfig.Current.Loader.Theme;
 
-            [Obsolete("Use LoaderConfig.Current.UnityEngine.DisableConsoleLogCleaner instead.")]
+            [Obsolete("Use LoaderConfig.Current.UnityEngine.DisableConsoleLogCleaner instead. This will be removed in a future update.", true)]
             public static bool CleanUnityLogs => !LoaderConfig.Current.UnityEngine.DisableConsoleLogCleaner;
 
-            [Obsolete("Use LoaderConfig.Current.Console.DontSetTitle instead.")]
+            [Obsolete("Use LoaderConfig.Current.Console.DontSetTitle instead. This will be removed in a future update.", true)]
             public static bool ShouldSetTitle => !LoaderConfig.Current.Console.DontSetTitle;
 
-            [Obsolete("Use LoaderConfig.Current.Console.AlwaysOnTop instead.")]
+            [Obsolete("Use LoaderConfig.Current.Console.AlwaysOnTop instead. This will be removed in a future update.", true)]
             public static bool AlwaysOnTop => LoaderConfig.Current.Console.AlwaysOnTop;
 
-            [Obsolete("Use LoaderConfig.Current.Console.Hide instead.")]
+            [Obsolete("Use LoaderConfig.Current.Console.Hide instead. This will be removed in a future update.", true)]
             public static bool ShouldHide => LoaderConfig.Current.Console.Hide;
 
-            [Obsolete("Use LoaderConfig.Current.Console.HideWarnings instead.")]
+            [Obsolete("Use LoaderConfig.Current.Console.HideWarnings instead. This will be removed in a future update.", true)]
             public static bool HideWarnings => LoaderConfig.Current.Console.HideWarnings;
         }
 
-        [Obsolete("Use LoaderConfig.Current.UnityEngine instead.")]
+        [Obsolete("Use LoaderConfig.Current.UnityEngine instead. This will be removed in a future update.", true)]
         public static class Cpp2IL
         {
-            [Obsolete("Use LoaderConfig.Current.UnityEngine.EnableCpp2ILCallAnalyzer instead.")]
+            [Obsolete("Use LoaderConfig.Current.UnityEngine.EnableCpp2ILCallAnalyzer instead. This will be removed in a future update.", true)]
             public static bool CallAnalyzer => LoaderConfig.Current.UnityEngine.EnableCpp2ILCallAnalyzer;
 
-            [Obsolete("Use LoaderConfig.Current.UnityEngine.EnableCpp2ILNativeMethodDetector instead.")]
+            [Obsolete("Use LoaderConfig.Current.UnityEngine.EnableCpp2ILNativeMethodDetector instead. This will be removed in a future update.", true)]
             public static bool NativeMethodDetector => LoaderConfig.Current.UnityEngine.EnableCpp2ILNativeMethodDetector;
         }
 
-        [Obsolete("Use LoaderConfig.Current.UnityEngine instead.")]
+        [Obsolete("Use LoaderConfig.Current.UnityEngine instead. This will be removed in a future update.", true)]
         public static class Il2CppAssemblyGenerator
         {
-            [Obsolete("Use LoaderConfig.Current.UnityEngine.ForceRegeneration instead.")]
+            [Obsolete("Use LoaderConfig.Current.UnityEngine.ForceRegeneration instead. This will be removed in a future update.", true)]
             public static bool ForceRegeneration => LoaderConfig.Current.UnityEngine.ForceRegeneration;
 
-            [Obsolete("Use LoaderConfig.Current.UnityEngine.ForceOfflineGeneration instead.")]
+            [Obsolete("Use LoaderConfig.Current.UnityEngine.ForceOfflineGeneration instead. This will be removed in a future update.", true)]
             public static bool OfflineMode => LoaderConfig.Current.UnityEngine.ForceOfflineGeneration;
 
-            [Obsolete("Use LoaderConfig.Current.UnityEngine.ForceIl2CppDumperVersion instead.")]
+            [Obsolete("Use LoaderConfig.Current.UnityEngine.ForceIl2CppDumperVersion instead. This will be removed in a future update.", true)]
             public static string ForceVersion_Dumper => LoaderConfig.Current.UnityEngine.ForceIl2CppDumperVersion;
 
-            [Obsolete("Use LoaderConfig.Current.UnityEngine.ForceGeneratorRegex instead.")]
+            [Obsolete("Use LoaderConfig.Current.UnityEngine.ForceGeneratorRegex instead. This will be removed in a future update.", true)]
             public static string ForceRegex => LoaderConfig.Current.UnityEngine.ForceGeneratorRegex;
         }
 
-        [Obsolete("Use LoaderConfig.Logs instead.")]
+        [Obsolete("Use LoaderConfig.Logs instead. This will be removed in a future update.", true)]
         public static class Logger
         {
-            [Obsolete("Use LoaderConfig.Current.Logs.MaxLogs instead.")]
+            [Obsolete("Use LoaderConfig.Current.Logs.MaxLogs instead. This will be removed in a future update.", true)]
             public static int MaxLogs => (int)LoaderConfig.Current.Logs.MaxLogs;
 
-            [Obsolete("This option isn't used anymore. It will always return 10.")]
+            [Obsolete("This option isn't used anymore. It will always return 10. This will be removed in a future update.", true)]
             public static int MaxWarnings => 10;
 
-            [Obsolete("This option isn't used anymore. It will always return 10.")]
+            [Obsolete("This option isn't used anymore. It will always return 10. This will be removed in a future update.", true)]
             public static int MaxErrors => 10;
         }
 

--- a/MelonLoader/MelonUtils.cs
+++ b/MelonLoader/MelonUtils.cs
@@ -18,8 +18,6 @@ using AssetsTools.NET.Extra;
 using MelonLoader.Lemons.Cryptography;
 using MelonLoader.Utils;
 
-#pragma warning disable 0618
-
 namespace MelonLoader
 {
     public static class MelonUtils
@@ -55,15 +53,15 @@ namespace MelonLoader
             CurrentDomain = IsGameIl2Cpp() ? MelonPlatformDomainAttribute.CompatibleDomains.IL2CPP : MelonPlatformDomainAttribute.CompatibleDomains.MONO;
         }
 
-        [Obsolete("Use MelonEnvironment.MelonBaseDirectory instead")]
+        [Obsolete("Use MelonEnvironment.MelonBaseDirectory instead. This will be removed in a future update.", true)]
         public static string BaseDirectory => MelonEnvironment.MelonBaseDirectory;
-        [Obsolete("Use MelonEnvironment.GameRootDirectory instead")]
+        [Obsolete("Use MelonEnvironment.GameRootDirectory instead. This will be removed in a future update.", true)]
         public static string GameDirectory => MelonEnvironment.GameRootDirectory;
-        [Obsolete("Use MelonEnvironment.MelonLoaderDirectory instead")]
+        [Obsolete("Use MelonEnvironment.MelonLoaderDirectory instead. This will be removed in a future update.", true)]
         public static string MelonLoaderDirectory => MelonEnvironment.MelonLoaderDirectory;
-        [Obsolete("Use MelonEnvironment.UserDataDirectory instead")]
+        [Obsolete("Use MelonEnvironment.UserDataDirectory instead. This will be removed in a future update.", true)]
         public static string UserDataDirectory => MelonEnvironment.UserDataDirectory;
-        [Obsolete("Use MelonEnvironment.UserLibsDirectory instead")]
+        [Obsolete("Use MelonEnvironment.UserLibsDirectory instead. This will be removed in a future update.", true)]
         public static string UserLibsDirectory => MelonEnvironment.UserLibsDirectory;
         public static MelonPlatformAttribute.CompatiblePlatforms CurrentPlatform { get; private set; }
         public static MelonPlatformDomainAttribute.CompatibleDomains CurrentDomain { get; private set; }
@@ -172,7 +170,7 @@ namespace MelonLoader
             => GetMelonFromAssembly(((MethodBase)StackFrameGetMethod.Invoke(sf, new object[0]))?.DeclaringType?.Assembly);
 
         private static MelonBase GetMelonFromAssembly(Assembly asm)
-            => asm == null ? null : MelonHandler.Plugins.Cast<MelonBase>().FirstOrDefault(x => x.Assembly == asm) ?? MelonHandler.Mods.FirstOrDefault(x => x.Assembly == asm);
+            => asm == null ? null : MelonPlugin.RegisteredMelons.Cast<MelonBase>().FirstOrDefault(x => x.MelonAssembly.Assembly == asm) ?? MelonMod.RegisteredMelons.FirstOrDefault(x => x.MelonAssembly.Assembly == asm);
 
         public static string ComputeSimpleSHA256Hash(string filePath)
         {
@@ -458,13 +456,13 @@ namespace MelonLoader
             return classPackage;
         }
 
-        [Obsolete("MelonLoader.MelonUtils.GetUnityVersion() is obsolete. Please use MelonLoader.InternalUtils.UnityInformationHandler.EngineVersion instead.")]
+        [Obsolete("MelonLoader.MelonUtils.GetUnityVersion() is obsolete. Please use MelonLoader.InternalUtils.UnityInformationHandler.EngineVersion instead. This will be removed in a future update.", true)]
         public static string GetUnityVersion() => UnityInformationHandler.EngineVersion.ToStringWithoutType();
-        [Obsolete("MelonLoader.MelonUtils.GameDeveloper is obsolete. Please use MelonLoader.InternalUtils.UnityInformationHandler.GameDeveloper instead.")]
+        [Obsolete("MelonLoader.MelonUtils.GameDeveloper is obsolete. Please use MelonLoader.InternalUtils.UnityInformationHandler.GameDeveloper instead. This will be removed in a future update.", true)]
         public static string GameDeveloper { get => UnityInformationHandler.GameDeveloper; }
-        [Obsolete("MelonLoader.MelonUtils.GameName is obsolete. Please use MelonLoader.InternalUtils.UnityInformationHandler.GameName instead.")]
+        [Obsolete("MelonLoader.MelonUtils.GameName is obsolete. Please use MelonLoader.InternalUtils.UnityInformationHandler.GameName instead. This will be removed in a future update.", true)]
         public static string GameName { get => UnityInformationHandler.GameName; }
-        [Obsolete("MelonLoader.MelonUtils.GameVersion is obsolete. Please use MelonLoader.InternalUtils.UnityInformationHandler.GameVersion instead.")]
+        [Obsolete("MelonLoader.MelonUtils.GameVersion is obsolete. Please use MelonLoader.InternalUtils.UnityInformationHandler.GameVersion instead. This will be removed in a future update.", true)]
         public static string GameVersion { get => UnityInformationHandler.GameVersion; }
 
 
@@ -483,21 +481,22 @@ namespace MelonLoader
 
         public static bool IsUnderWineOrSteamProton() => WineGetVersion is not null;
 
-        [Obsolete("Use MelonEnvironment.GameExecutablePath instead")]
+        [Obsolete("Use MelonEnvironment.GameExecutablePath instead. This will be removed in a future update.", true)]
         public static string GetApplicationPath() => MelonEnvironment.GameExecutablePath;
 
-        [Obsolete("Use MelonEnvironment.UnityGameDataDirectory instead")]
+        [Obsolete("Use MelonEnvironment.UnityGameDataDirectory instead. This will be removed in a future update.", true)]
         public static string GetGameDataDirectory() => MelonEnvironment.UnityGameDataDirectory;
 
-        [Obsolete("Use MelonEnvironment.MelonManagedDirectory instead")]
+        [Obsolete("Use MelonEnvironment.MelonManagedDirectory instead. This will be removed in a future update.", true)]
         public static string GetManagedDirectory() => MelonEnvironment.MelonManagedDirectory;
 
         public static void SetConsoleTitle(string title)
         {
-            if (!MelonLaunchOptions.Console.ShouldSetTitle || MelonLaunchOptions.Console.ShouldHide)
+            if (LoaderConfig.Current.Console.DontSetTitle || !BootstrapInterop.Library.IsConsoleOpen())
                 return;
 
-            Console.Title = title;
+            // Using reflection to avoid resolver errors
+            AccessTools.Property(typeof(Console), "Title")?.SetValue(null, title, null);
         }
 
         public static string GetFileProductName(string filepath)
@@ -611,13 +610,13 @@ namespace MelonLoader
             return $"{versionString}";
         }
 
-        [Obsolete("Use NativeUtils.NativeHook instead")]
+        [Obsolete("Use NativeUtils.NativeHook instead. This will be removed in a future update.", true)]
         public static void NativeHookAttach(IntPtr target, IntPtr detour) => BootstrapInterop.NativeHookAttach(target, detour);
 
-        [Obsolete("Use NativeUtils.NativeHook instead")]
+        [Obsolete("Use NativeUtils.NativeHook instead. This will be removed in a future update.", true)]
         internal static void NativeHookAttachDirect(IntPtr target, IntPtr detour) => BootstrapInterop.NativeHookAttachDirect(target, detour);
 
-        [Obsolete("Use NativeUtils.NativeHook instead")]
+        [Obsolete("Use NativeUtils.NativeHook instead. This will be removed in a future update.", true)]
         public static void NativeHookDetach(IntPtr target, IntPtr detour) => BootstrapInterop.NativeHookDetach(target, detour);
 
 

--- a/MelonLoader/Melons/MelonBase.cs
+++ b/MelonLoader/Melons/MelonBase.cs
@@ -312,7 +312,7 @@ namespace MelonLoader
 
         public Incompatibility[] FindIncompatiblitiesFromContext()
         {
-            return FindIncompatiblities(MelonUtils.CurrentGameAttribute, Process.GetCurrentProcess().ProcessName, MelonUtils.GameVersion, BuildInfo.VersionNumber, MelonUtils.HashCode, MelonUtils.CurrentPlatform, MelonUtils.CurrentDomain);
+            return FindIncompatiblities(MelonUtils.CurrentGameAttribute, Process.GetCurrentProcess().ProcessName, UnityInformationHandler.GameVersion, BuildInfo.VersionNumber, MelonUtils.HashCode, MelonUtils.CurrentPlatform, MelonUtils.CurrentDomain);
         }
 
         public static void PrintIncompatibilities(Incompatibility[] incompatibilities, MelonBase melon)
@@ -380,7 +380,7 @@ namespace MelonLoader
 
             if (FindMelon(Info.Name, Info.Author) != null)
             {
-                MelonLogger.Warning($"Failed to register {MelonTypeName} '{Location}': A Melon with the same Name and Author is already registered!");
+                MelonLogger.Warning($"Failed to register {MelonTypeName} '{MelonAssembly.Location}': A Melon with the same Name and Author is already registered!");
                 return false;
             }
 
@@ -394,7 +394,7 @@ namespace MelonLoader
             OnMelonInitializing.Invoke(this);
 
             LoggerInstance ??= new MelonLogger.Instance(string.IsNullOrEmpty(ID) ? Info.Name : $"{ID}:{Info.Name}", ConsoleColor);
-            HarmonyInstance ??= new HarmonyLib.Harmony($"{Assembly.FullName}:{Info.Name}");
+            HarmonyInstance ??= new HarmonyLib.Harmony($"{MelonAssembly.Assembly.FullName}:{Info.Name}");
 
             Registered = true; // this has to be true before the melon can subscribe to any events
             RegisterCallbacks();
@@ -405,7 +405,7 @@ namespace MelonLoader
             }
             catch (Exception ex)
             {
-                MelonLogger.Error($"Failed to register {MelonTypeName} '{Location}': Melon failed to initialize!");
+                MelonLogger.Error($"Failed to register {MelonTypeName} '{MelonAssembly.Location}': Melon failed to initialize!");
                 MelonLogger.Error(ex.ToString());
                 Registered = false;
                 return false;
@@ -466,16 +466,34 @@ namespace MelonLoader
             MelonEvents.OnLateUpdate.Subscribe(OnLateUpdate, Priority);
             MelonEvents.OnGUI.Subscribe(OnGUI, Priority);
             MelonEvents.OnFixedUpdate.Subscribe(OnFixedUpdate, Priority);
-            MelonEvents.OnApplicationLateStart.Subscribe(OnApplicationLateStart, Priority);
+
+#pragma warning disable CS0612 // Type or member is obsolete
+            RegisterObsoleteCallbacks();
+#pragma warning restore CS0612 // Type or member is obsolete
 
             MelonPreferences.OnPreferencesLoaded.Subscribe(PrefsLoaded, Priority);
             MelonPreferences.OnPreferencesSaved.Subscribe(PrefsSaved, Priority);
+        }
+
+        [Obsolete]
+        private void RegisterObsoleteCallbacks()
+        {
+            MelonEvents.OnApplicationLateStart.Subscribe(OnApplicationLateStart, Priority);
         }
 
         private void PrefsSaved(string path)
         {
             OnPreferencesSaved(path);
             OnPreferencesSaved();
+
+#pragma warning disable CS0612 // Type or member is obsolete
+            PrefsSavedObsoleteCallback();
+#pragma warning restore CS0612 // Type or member is obsolete
+        }
+
+        [Obsolete]
+        private void PrefsSavedObsoleteCallback()
+        {
             OnModSettingsApplied();
         }
 
@@ -516,7 +534,7 @@ namespace MelonLoader
             }
             catch (Exception ex)
             {
-                MelonLogger.Error($"Failed to properly unregister {MelonTypeName} '{Location}': Melon failed to deinitialize!");
+                MelonLogger.Error($"Failed to properly unregister {MelonTypeName} '{MelonAssembly.Location}': Melon failed to deinitialize!");
                 MelonLogger.Error(ex.ToString());
             }
 
@@ -618,35 +636,36 @@ namespace MelonLoader
 
         #region Obsolete Members
 
+        [Obsolete]
         private Harmony.HarmonyInstance _OldHarmonyInstance;
 
-        [Obsolete("Please use either the OnLateInitializeMelon callback, or the 'MelonEvents::OnApplicationLateStart' event instead.")]
+        [Obsolete("Please use either the OnLateInitializeMelon callback, or the 'MelonEvents::OnApplicationLateStart' event instead. This will be removed in a future update.", true)]
         public virtual void OnApplicationLateStart() { }
 
-        [Obsolete("For mods, use OnInitializeMelon instead. For plugins, use OnPreModsLoaded instead.")]
+        [Obsolete("For mods, use OnInitializeMelon instead. For plugins, use OnPreModsLoaded instead. This will be removed in a future update.", true)]
         public virtual void OnApplicationStart() { }
 
-        [Obsolete("Please use OnPreferencesSaved instead.")]
+        [Obsolete("Please use OnPreferencesSaved instead. This will be removed in a future update.", true)]
         public virtual void OnModSettingsApplied() { }
 
-        [Obsolete("Please use HarmonyInstance instead.")]
+        [Obsolete("Please use HarmonyInstance instead. This will be removed in a future update.", true)]
 #pragma warning disable IDE1006 // Naming Styles
         public Harmony.HarmonyInstance harmonyInstance { get { _OldHarmonyInstance ??= new Harmony.HarmonyInstance(HarmonyInstance.Id); return _OldHarmonyInstance; } }
 #pragma warning restore IDE1006 // Naming Styles
 
-        [Obsolete("Please use HarmonyInstance instead.")]
+        [Obsolete("Please use HarmonyInstance instead. This will be removed in a future update.", true)]
         public Harmony.HarmonyInstance Harmony { get { _OldHarmonyInstance ??= new Harmony.HarmonyInstance(HarmonyInstance.Id); return _OldHarmonyInstance; } }
 
-        [Obsolete("Please use MelonAssembly.Assembly instead.")]
+        [Obsolete("Please use MelonAssembly.Assembly instead. This will be removed in a future update.", true)]
         public Assembly Assembly => MelonAssembly.Assembly;
 
-        [Obsolete("Please use MelonAssembly.HarmonyDontPatchAll instead.")]
+        [Obsolete("Please use MelonAssembly.HarmonyDontPatchAll instead. This will be removed in a future update.", true)]
         public bool HarmonyDontPatchAll => MelonAssembly.HarmonyDontPatchAll;
 
-        [Obsolete("Please use MelonAssembly.Hash instead.")]
+        [Obsolete("Please use MelonAssembly.Hash instead. This will be removed in a future update.", true)]
         public string Hash => MelonAssembly.Hash;
 
-        [Obsolete("Please use MelonAssembly.Location instead.")]
+        [Obsolete("Please use MelonAssembly.Location instead. This will be removed in a future update.", true)]
         public string Location => MelonAssembly.Location;
 
         #endregion

--- a/MelonLoader/Melons/MelonHandler.cs
+++ b/MelonLoader/Melons/MelonHandler.cs
@@ -14,13 +14,13 @@ namespace MelonLoader
         /// <summary>
         /// Directory of Plugins.
         /// </summary>
-        [Obsolete("Use MelonEnvironment.PluginsDirectory instead")]
+        [Obsolete("Use MelonEnvironment.PluginsDirectory instead. This will be removed in a future update.", true)]
         public static string PluginsDirectory => MelonEnvironment.PluginsDirectory;
 
         /// <summary>
         /// Directory of Mods.
         /// </summary>
-        [Obsolete("Use MelonEnvironment.ModsDirectory instead")]
+        [Obsolete("Use MelonEnvironment.ModsDirectory instead. This will be removed in a future update.", true)]
         public static string ModsDirectory => MelonEnvironment.ModsDirectory;
 
         internal static void Setup()
@@ -45,44 +45,44 @@ namespace MelonLoader
         /// <summary>
         /// List of Plugins.
         /// </summary>
-        [Obsolete("Use 'MelonPlugin.RegisteredMelons' instead.")]
+        [Obsolete("Use 'MelonPlugin.RegisteredMelons' instead. This will be removed in a future update.", true)]
         public static List<MelonPlugin> Plugins => MelonTypeBase<MelonPlugin>.RegisteredMelons.ToList();
 
         /// <summary>
         /// List of Mods.
         /// </summary>
-        [Obsolete("Use 'MelonMod.RegisteredMelons' instead.")]
+        [Obsolete("Use 'MelonMod.RegisteredMelons' instead. This will be removed in a future update.", true)]
         public static List<MelonMod> Mods => MelonTypeBase<MelonMod>.RegisteredMelons.ToList();
 
-        [Obsolete("Use 'MelonBase.Load' and 'MelonBase.Register' instead.")]
+        [Obsolete("Use 'MelonBase.Load' and 'MelonBase.Register' instead. This will be removed in a future update.", true)]
         public static void LoadFromFile(string filelocation, bool is_plugin) => LoadFromFile(filelocation);
 
-        [Obsolete("Use 'MelonBase.Load' and 'MelonBase.Register' instead.")]
+        [Obsolete("Use 'MelonBase.Load' and 'MelonBase.Register' instead. This will be removed in a future update.", true)]
         public static void LoadFromByteArray(byte[] filedata, string filelocation) => LoadFromByteArray(filedata, filepath: filelocation);
 
-        [Obsolete("Use 'MelonBase.Load' and 'MelonBase.Register' instead.")]
+        [Obsolete("Use 'MelonBase.Load' and 'MelonBase.Register' instead. This will be removed in a future update.", true)]
         public static void LoadFromByteArray(byte[] filedata, string filelocation, bool is_plugin) => LoadFromByteArray(filedata, filepath: filelocation);
 
-        [Obsolete("Use 'MelonBase.Load' and 'MelonBase.Register' instead.")]
+        [Obsolete("Use 'MelonBase.Load' and 'MelonBase.Register' instead. This will be removed in a future update.", true)]
         public static void LoadFromAssembly(Assembly asm, string filelocation, bool is_plugin) => LoadFromAssembly(asm, filelocation);
 
-        [Obsolete("Use 'MelonBase.Hash' instead.")]
+        [Obsolete("Use 'MelonBase.Hash' instead. This will be removed in a future update.", true)]
         public static string GetMelonHash(MelonBase melonBase)
             => melonBase.Hash;
 
-        [Obsolete("Use 'MelonBase.RegisteredMelons.Exists(1)' instead.")]
+        [Obsolete("Use 'MelonBase.RegisteredMelons.Exists(1)' instead. This will be removed in a future update.", true)]
         public static bool IsMelonAlreadyLoaded(string name)
             => MelonBase._registeredMelons.Exists(x => x.Info.Name == name);
 
-        [Obsolete("Use 'MelonPlugin.RegisteredMelons.Exists(1)' instead.")]
+        [Obsolete("Use 'MelonPlugin.RegisteredMelons.Exists(1)' instead. This will be removed in a future update.", true)]
         public static bool IsPluginAlreadyLoaded(string name)
             => MelonTypeBase<MelonPlugin>._registeredMelons.Exists(x => x.Info.Name == name);
 
-        [Obsolete("Use 'MelonMod.RegisteredMelons.Exists(1)' instead.")]
+        [Obsolete("Use 'MelonMod.RegisteredMelons.Exists(1)' instead. This will be removed in a future update.", true)]
         public static bool IsModAlreadyLoaded(string name)
             => MelonTypeBase<MelonMod>._registeredMelons.Exists(x => x.Info.Name == name);
 
-        [Obsolete("Use 'MelonBase.Load' and 'MelonBase.Register' instead.")]
+        [Obsolete("Use 'MelonBase.Load' and 'MelonBase.Register' instead. This will be removed in a future update.", true)]
         public static void LoadFromFile(string filepath, string symbolspath = null)
         {
             var asm = MelonAssembly.LoadMelonAssembly(filepath);
@@ -92,7 +92,7 @@ namespace MelonLoader
             MelonBase.RegisterSorted(asm.LoadedMelons);
         }
 
-        [Obsolete("Use 'MelonBase.Load' and 'MelonBase.Register' instead.")]
+        [Obsolete("Use 'MelonBase.Load' and 'MelonBase.Register' instead. This will be removed in a future update.", true)]
         public static void LoadFromByteArray(byte[] filedata, byte[] symbolsdata = null, string filepath = null)
         {
             var asm = MelonAssembly.LoadRawMelonAssembly(filepath, filedata, symbolsdata);
@@ -102,7 +102,7 @@ namespace MelonLoader
             MelonBase.RegisterSorted(asm.LoadedMelons);
         }
 
-        [Obsolete("Use 'MelonBase.Load' and 'MelonBase.Register' instead.")]
+        [Obsolete("Use 'MelonBase.Load' and 'MelonBase.Register' instead. This will be removed in a future update.", true)]
         public static void LoadFromAssembly(Assembly asm, string filepath = null)
         {
             var ma = MelonAssembly.LoadMelonAssembly(filepath, asm);

--- a/MelonLoader/Melons/MelonMod.cs
+++ b/MelonLoader/Melons/MelonMod.cs
@@ -19,7 +19,7 @@ namespace MelonLoader
             }
             catch (Exception ex)
             {
-                MelonLogger.Error($"Failed to register {MelonTypeName} '{Location}': Melon failed to initialize in the deprecated OnPreSupportModule callback!");
+                MelonLogger.Error($"Failed to register {MelonTypeName} '{MelonAssembly.Location}': Melon failed to initialize in the deprecated OnPreSupportModule callback!");
                 MelonLogger.Error(ex.ToString());
                 return false;
             }
@@ -48,6 +48,14 @@ namespace MelonLoader
             MelonEvents.OnSceneWasInitialized.Subscribe(OnSceneWasInitialized, Priority);
             MelonEvents.OnSceneWasUnloaded.Subscribe(OnSceneWasUnloaded, Priority);
 
+#pragma warning disable CS0612 // Type or member is obsolete
+            RegisterObsoleteCallbacks();
+#pragma warning restore CS0612 // Type or member is obsolete
+        }
+
+        [Obsolete]
+        private void RegisterObsoleteCallbacks()
+        {
             MelonEvents.OnSceneWasLoaded.Subscribe((idx, name) => OnLevelWasLoaded(idx), Priority);
             MelonEvents.OnSceneWasInitialized.Subscribe((idx, name) => OnLevelWasInitialized(idx), Priority);
             MelonEvents.OnApplicationStart.Subscribe(OnApplicationStart, Priority);
@@ -73,18 +81,18 @@ namespace MelonLoader
         #endregion
 
         #region Obsolete Members
-        [Obsolete("Override OnSceneWasLoaded instead.")]
+        [Obsolete("Override OnSceneWasLoaded instead. This will be removed in a future update.", true)]
         public virtual void OnLevelWasLoaded(int level) { }
-        [Obsolete("Override OnSceneWasInitialized instead.")]
+        [Obsolete("Override OnSceneWasInitialized instead. This will be removed in a future update.", true)]
         public virtual void OnLevelWasInitialized(int level) { }
 
         [Obsolete()]
         private MelonModInfoAttribute _LegacyInfoAttribute = null;
-        [Obsolete("Use MelonBase.Info instead.")]
+        [Obsolete("Use MelonBase.Info instead. This will be removed in a future update.", true)]
         public MelonModInfoAttribute InfoAttribute { get { if (_LegacyInfoAttribute == null) _LegacyInfoAttribute = new MelonModInfoAttribute(Info.SystemType, Info.Name, Info.Version, Info.Author, Info.DownloadLink); return _LegacyInfoAttribute; } }
         [Obsolete()]
         private MelonModGameAttribute[] _LegacyGameAttributes = null;
-        [Obsolete("Use MelonBase.Games instead.")]
+        [Obsolete("Use MelonBase.Games instead. This will be removed in a future update.", true)]
         public MelonModGameAttribute[] GameAttributes { get {
                 if (_LegacyGameAttributes != null)
                     return _LegacyGameAttributes;

--- a/MelonLoader/Melons/MelonPlugin.cs
+++ b/MelonLoader/Melons/MelonPlugin.cs
@@ -18,9 +18,19 @@ namespace MelonLoader
             MelonEvents.OnPreInitialization.Subscribe(OnPreInitialization, Priority);
             MelonEvents.OnApplicationEarlyStart.Subscribe(OnApplicationEarlyStart, Priority);
             MelonEvents.OnPreModsLoaded.Subscribe(OnPreModsLoaded, Priority);
-            MelonEvents.OnPreModsLoaded.Subscribe(OnApplicationStart, Priority);
+
+#pragma warning disable CS0612 // Type or member is obsolete
+            RegisterObsoleteCallbacks();
+#pragma warning restore CS0612 // Type or member is obsolete
+
             MelonEvents.OnApplicationStart.Subscribe(OnApplicationStarted, Priority);
             MelonEvents.OnPreSupportModule.Subscribe(OnPreSupportModule, Priority);
+        }
+
+        [Obsolete]
+        private void RegisterObsoleteCallbacks()
+        {
+            MelonEvents.OnPreModsLoaded.Subscribe(OnApplicationStart, Priority);
         }
 
         protected private override bool RegisterInternal()
@@ -69,11 +79,11 @@ namespace MelonLoader
 
         [Obsolete()]
         private MelonPluginInfoAttribute _LegacyInfoAttribute = null;
-        [Obsolete("MelonPlugin.InfoAttribute is obsolete. Please use MelonBase.Info instead.")]
+        [Obsolete("MelonPlugin.InfoAttribute is obsolete. Please use MelonBase.Info instead. This will be removed in a future update.", true)]
         public MelonPluginInfoAttribute InfoAttribute { get { if (_LegacyInfoAttribute == null) _LegacyInfoAttribute = new MelonPluginInfoAttribute(Info.SystemType, Info.Name, Info.Version, Info.Author, Info.DownloadLink); return _LegacyInfoAttribute; } }
         [Obsolete()]
         private MelonPluginGameAttribute[] _LegacyGameAttributes = null;
-        [Obsolete("MelonPlugin.GameAttributes is obsolete. Please use MelonBase.Games instead.")]
+        [Obsolete("MelonPlugin.GameAttributes is obsolete. Please use MelonBase.Games instead. This will be removed in a future update.", true)]
         public MelonPluginGameAttribute[] GameAttributes
         {
             get

--- a/MelonLoader/Preferences/MelonPreferences_Entry.cs
+++ b/MelonLoader/Preferences/MelonPreferences_Entry.cs
@@ -41,7 +41,7 @@ namespace MelonLoader
             OnValueChangedUntyped?.Invoke();
         }
 
-        [Obsolete("Please use the OnEntryValueChangedUntyped MelonEvent instead.")]
+        [Obsolete("Please use the OnEntryValueChangedUntyped MelonEvent instead. This will be removed in a future update.", true)]
         public event Action OnValueChangedUntyped;
     }
 
@@ -87,7 +87,7 @@ namespace MelonLoader
 
         public readonly MelonEvent<T, T> OnEntryValueChanged = new MelonEvent<T, T>();
 
-        [Obsolete("Please use the OnEntryValueChanged MelonEvent instead.")]
+        [Obsolete("Please use the OnEntryValueChanged MelonEvent instead. This will be removed in a future update.", true)]
         public event Action<T, T> OnValueChanged;
 
         public override Type GetReflectedType() => typeof(T);

--- a/MelonLoader/Resolver/MelonAssemblyResolver.cs
+++ b/MelonLoader/Resolver/MelonAssemblyResolver.cs
@@ -109,10 +109,20 @@ namespace MelonLoader.Resolver
         {
 #if !NET6_0_OR_GREATER
             // Backwards Compatibility
-            MonoInternals.MonoResolveManager.SafeInvoke_OnAssemblyLoad(assembly);
+#pragma warning disable CS0612 // Type or member is obsolete
+            InvokeObsoleteOnAssemblyLoad(assembly);
+#pragma warning restore CS0612 // Type or member is obsolete
 #endif
             OnAssemblyLoad?.Invoke(assembly);
         }
+
+#if !NET6_0_OR_GREATER
+        [Obsolete]
+        private static void InvokeObsoleteOnAssemblyLoad(Assembly assembly)
+        {
+            MonoInternals.MonoResolveManager.SafeInvoke_OnAssemblyLoad(assembly);
+        }
+#endif
 
         public delegate Assembly OnAssemblyResolveHandler(string name, Version version);
         public static event OnAssemblyResolveHandler OnAssemblyResolve;
@@ -125,13 +135,24 @@ namespace MelonLoader.Resolver
 #else
 
             // Backwards Compatibility
-            var assembly = MonoInternals.MonoResolveManager.SafeInvoke_OnAssemblyResolve(name, version);
+#pragma warning disable CS0612 // Type or member is obsolete
+            var assembly = InvokeObsoleteOnAssemblyResolve(name, version);
+#pragma warning restore CS0612 // Type or member is obsolete
+
             if (assembly == null)
                 assembly = OnAssemblyResolve?.Invoke(name, version);
             return assembly;
 
 #endif
         }
+
+#if !NET6_0_OR_GREATER
+        [Obsolete]
+        private static Assembly InvokeObsoleteOnAssemblyResolve(string name, Version version)
+        {
+            return MonoInternals.MonoResolveManager.SafeInvoke_OnAssemblyResolve(name, version);
+        }
+#endif
 
         public static AssemblyResolveInfo GetAssemblyResolveInfo(string name)
             => AssemblyManager.GetInfo(name);

--- a/MelonLoader/Utils/MelonLogger.cs
+++ b/MelonLoader/Utils/MelonLogger.cs
@@ -144,7 +144,7 @@ namespace MelonLoader
             MsgDrawingCallbackHandler?.Invoke(namesection_color, txt_color, namesection, txt);
         }
 
-        [Obsolete("MsgCallbackHandler is obsolete. Please use MsgDrawingCallbackHandler for full Color support.")]
+        [Obsolete("MsgCallbackHandler is obsolete. Please use MsgDrawingCallbackHandler for full Color support. This will be removed in a future update.", true)]
         public static event Action<ConsoleColor, ConsoleColor, string, string> MsgCallbackHandler;
 
         public static event Action<Color, Color, string, string> MsgDrawingCallbackHandler;
@@ -161,7 +161,7 @@ namespace MelonLoader
         {
             private string Name = null;
 
-            [Obsolete("Color is obsolete. Please use DrawingColor for full Color support.")]
+            [Obsolete("Color is obsolete. Please use DrawingColor for full Color support. This will be removed in a future update.", true)]
             private ConsoleColor Color
             {
                 get => DrawingColorToConsoleColor(DrawingColor);
@@ -172,7 +172,7 @@ namespace MelonLoader
 
             public Instance(string name) => Name = name?.Replace(" ", "_");
 
-            [Obsolete("ConsoleColor is obsolete, use the (string, Color) constructor instead.")]
+            [Obsolete("ConsoleColor is obsolete, use the (string, Color) constructor instead. This will be removed in a future update.", true)]
             public Instance(string name, ConsoleColor color) : this(name) => Color = color;
 
             public Instance(string name, Color color) : this(name) => DrawingColor = color;
@@ -318,34 +318,34 @@ namespace MelonLoader
             }
         }
 
-        [Obsolete("Log is obsolete. Please use Msg instead.")]
+        [Obsolete("Log is obsolete. Please use Msg instead. This will be removed in a future update.", true)]
         public static void Log(string txt) => Msg(txt);
 
-        [Obsolete("Log is obsolete. Please use Msg instead.")]
+        [Obsolete("Log is obsolete. Please use Msg instead. This will be removed in a future update.", true)]
         public static void Log(string txt, params object[] args) => Msg(txt, args);
 
-        [Obsolete("Log is obsolete. Please use Msg instead.")]
+        [Obsolete("Log is obsolete. Please use Msg instead. This will be removed in a future update.", true)]
         public static void Log(object obj) => Msg(obj);
 
-        [Obsolete("Log is obsolete. Please use Msg instead.")]
+        [Obsolete("Log is obsolete. Please use Msg instead. This will be removed in a future update.", true)]
         public static void Log(ConsoleColor color, string txt) => Msg(color, txt);
 
-        [Obsolete("Log is obsolete. Please use Msg instead.")]
+        [Obsolete("Log is obsolete. Please use Msg instead. This will be removed in a future update.", true)]
         public static void Log(ConsoleColor color, string txt, params object[] args) => Msg(color, txt, args);
 
-        [Obsolete("Log is obsolete. Please use Msg instead.")]
+        [Obsolete("Log is obsolete. Please use Msg instead. This will be removed in a future update.", true)]
         public static void Log(ConsoleColor color, object obj) => Msg(color, obj);
 
-        [Obsolete("LogWarning is obsolete. Please use Warning instead.")]
+        [Obsolete("LogWarning is obsolete. Please use Warning instead. This will be removed in a future update.", true)]
         public static void LogWarning(string txt) => Warning(txt);
 
-        [Obsolete("LogWarning is obsolete. Please use Warning instead.")]
+        [Obsolete("LogWarning is obsolete. Please use Warning instead. This will be removed in a future update.", true)]
         public static void LogWarning(string txt, params object[] args) => Warning(txt, args);
 
-        [Obsolete("LogError is obsolete. Please use Error instead.")]
+        [Obsolete("LogError is obsolete. Please use Error instead. This will be removed in a future update.", true)]
         public static void LogError(string txt) => Error(txt);
 
-        [Obsolete("LogError is obsolete. Please use Error instead.")]
+        [Obsolete("LogError is obsolete. Please use Error instead. This will be removed in a future update.", true)]
         public static void LogError(string txt, params object[] args) => Error(txt, args);
     }
 }


### PR DESCRIPTION
This will force developers to move away from obsolete API, without breaking already-compiled mods.