### PR TITLE
Adds Warning Text When PlayerSettings Is Unavailable

### DIFF
--- a/MelonLoader/InternalUtils/UnityInformationHandler.cs
+++ b/MelonLoader/InternalUtils/UnityInformationHandler.cs
@@ -122,6 +122,10 @@ namespace MelonLoader.InternalUtils
                         if (productName != null)
                             GameName = productName.AsString;
                     }
+                    else
+                    {
+                        MelonLogger.Warning("Unable to find PlayerSettings in globalgamemanagers. Possible out-dated classdata.tpk present. Using fallback method.");
+                    }
                 }
             }
             catch(Exception ex)


### PR DESCRIPTION
Currently there is little information provided to the user when the classdata.tpk file is potentially out-of-date, which will cause the fallback method to run without proper game version information being entered into Latest.log

This additional log entry:
- Provides users more clarity in situations when the ReadGameInfoFallback method is being called upon
- Provides helpful feedback on a potential cause for the issue