### PR TITLE
Add the ability to override the corlibs assemblies path

### DIFF
--- a/MelonLoader.Bootstrap/Core.cs
+++ b/MelonLoader.Bootstrap/Core.cs
@@ -136,6 +136,10 @@ public static class Core
         if (ArgParser.IsDefined("melonloader.disableunityclc"))
             LoaderConfig.Current.UnityEngine.DisableConsoleLogCleaner = true;
 
+        var monoSearchPathOverride = ArgParser.GetValue("melonloader.monosearchpathoverride");
+        if (monoSearchPathOverride != null)
+            LoaderConfig.Current.UnityEngine.MonoSearchPathOverride = monoSearchPathOverride;
+
         if (ArgParser.IsDefined("melonloader.agfregenerate"))
             LoaderConfig.Current.UnityEngine.ForceRegeneration = true;
 

--- a/MelonLoader.Bootstrap/RuntimeHandlers/Mono/MonoLib.cs
+++ b/MelonLoader.Bootstrap/RuntimeHandlers/Mono/MonoLib.cs
@@ -42,6 +42,8 @@ internal class MonoLib
     public required RuntimeInvokeFn RuntimeInvoke { get; init; }
     public required StringNewFn StringNew { get; init; }
     public required AssemblyGetObjectFn AssemblyGetObject { get; init; }
+    public required SetAssembliesPathFn SetAssembliesPath { get; init; }
+    public required AssemblyGetrootdirFn AssemblyGetrootdir { get; init; }
     public required MethodGetNameFn MethodGetName { get; init; }
     public required AddInternalCallFn AddInternalCall { get; init; }
     public required DomainAssemblyOpenFn DomainAssemblyOpen { get; init; }
@@ -83,6 +85,8 @@ internal class MonoLib
             || !NativeFunc.GetExport<StringNewFn>(hRuntime, "mono_string_new", out var stringNew)
             || !NativeFunc.GetExport<AssemblyGetObjectFn>(hRuntime, "mono_assembly_get_object", out var assemblyGetObject)
             || !NativeFunc.GetExport<MethodGetNameFn>(hRuntime, "mono_method_get_name", out var methodGetName)
+            || !NativeFunc.GetExport<SetAssembliesPathFn>(hRuntime, "mono_set_assemblies_path", out var setAssembliesPath)
+            || !NativeFunc.GetExport<AssemblyGetrootdirFn>(hRuntime, "mono_assembly_getrootdir", out var assemblyGetRootDir)
             || !NativeFunc.GetExport<AddInternalCallFn>(hRuntime, "mono_add_internal_call", out var addInternalCall)
             || !NativeFunc.GetExport<DomainAssemblyOpenFn>(hRuntime, "mono_domain_assembly_open", out var domainAssemblyOpen)
             || !NativeFunc.GetExport<AssemblyGetImageFn>(hRuntime, "mono_assembly_get_image", out var assemblyGetImage)
@@ -115,6 +119,8 @@ internal class MonoLib
             StringNew = stringNew,
             AssemblyGetObject = assemblyGetObject,
             MethodGetName = methodGetName,
+            SetAssembliesPath = setAssembliesPath,
+            AssemblyGetrootdir = assemblyGetRootDir,
             AddInternalCall = addInternalCall,
             DomainAssemblyOpen = domainAssemblyOpen,
             AssemblyGetImage = assemblyGetImage,
@@ -219,6 +225,10 @@ internal class MonoLib
     public unsafe delegate nint RuntimeInvokeFn(nint method, nint obj, void** args, ref nint ex);
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate nint AssemblyGetObjectFn(nint domain, nint assembly);
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate nint SetAssembliesPathFn(string domain);
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate string AssemblyGetrootdirFn();
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate nint InstallAssemblyPreloadHookFn(AssemblyPreloadHookFn func, nint userData);

--- a/MelonLoader/LoaderConfig.cs
+++ b/MelonLoader/LoaderConfig.cs
@@ -117,6 +117,14 @@ public class LoaderConfig
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
     public class UnityEngineConfig
     {
+        [TomlNonSerialized]
+        private const string MonoPathSeparatorDescription =
+#if WINDOWS
+            "semicolon (;)";
+#elif LINUX
+            "colon (:)";
+#endif
+
         [TomlProperty("version_override")]
         [TomlPrecedingComment("Overrides the detected UnityEngine version. Equivalent to the '--melonloader.unityversion' launch option")]
         public string VersionOverride { get; internal set; } = "";
@@ -124,6 +132,10 @@ public class LoaderConfig
         [TomlProperty("disable_console_log_cleaner")]
         [TomlPrecedingComment("Disables the console log cleaner (only applies to Il2Cpp games). Equivalent to the '--melonloader.disableunityclc' launch option")]
         public bool DisableConsoleLogCleaner { get; internal set; }
+
+        [TomlProperty("mono_search_path_override")]
+        [TomlPrecedingComment($"A {MonoPathSeparatorDescription} separated list of paths that Mono will prioritise to seek mscorlib and core libraries before the Managed folder and Melon's included set of core libraries. Equivalent to the '--melonloader.monosearchpathoverride' launch option")]
+        public string MonoSearchPathOverride { get; internal set; } = "";
 
         [TomlProperty("force_offline_generation")]
         [TomlPrecedingComment("Forces the Il2Cpp Assembly Generator to run without contacting the remote API. Equivalent to the '--melonloader.agfoffline' launch option")]

--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ enable_cpp2il_native_method_detector = false
 | --melonloader.agfregex | Forces Assembly Generator to use a Specified Regex |
 | --melonloader.agfvdumper | Forces Assembly Generator to use a Specified Version of Dumper |
 | --melonloader.disableunityclc | Disable Unity Console Log Cleaner |
+| --melonloader.monosearchpathoverride | A list of paths that Mono will prioritise to seek mscorlib and core libraries before the Managed folder and Melon's included set of core libraries. The list is separated by semicolons (;) on Windows and by colons (:) on Linux |
 
 
 - These ones below are Cpp2IL specific Launch Options.


### PR DESCRIPTION
A new method to remedy the problem of stripped, stubbed or any other weirdness done to the corlibs caused by unity or devs, inspired by how Doorstop handles it.

Essentially, it uses `mono_set_assemblies_path` and the way it works is you specify a list of paths that Mono will prioritise in assembly resolution. It takes effects as soon as mono starts so it's ideal for overriding corlibs and it supercedes the way melon has been doing it (which is pick some, hope they'll work and manually load the assemblies).

It adds a setting where the default is emulating the behavior of current melon which is:
- On new mono, it's `mono_getrootdir` which will typically be the game's Managed folder
- On old mono, it's the NetStandardPatches folder THEN the getrootdir so the project's corlibs takes priority

This already means we no longer need to manually load the assemblies: mono will always load them before the Managed folder when it wants.

But the biggest improvement is the ability to override the path IN GENERAL when putting a value to the setting. Since mono (and doorstop's setting) supports having multiple paths, I did the same, but keep in mind the separator is platform dependant (they were chosen because they match the ones mono uses and they happen to work perfectly for their matching platforms). Paths can be relative or absolute, this PR will convert all of them to absolute though and build the strings accordingly.

What's important is that custom path ALWAYS goes before anything else so in the event that the project's corlibs aren't enough (which I have encountered before) or don't work, it's possible to specify a different set that would override the melon's ones. I tend to put my set in a folder called "corlibs" at the game's directory and set the setting to "corlibs".

As for where to get a suitable set, thanks to https://github.com/BepInEx/UnityDataMiner, we have a lot of known good sets! They are published here: https://unity.bepinex.dev/corlibs/ and while not exhaustive, they cover enough that I haven't ran into problems.

For example, UE requires System.Reflection.Emit for its console to work, but some unity versions builds games with an mscorlib.dll that have these stubbed. Since melon doesn't (and can't) provide an mscorlib that works everywhere, this is where the website above comes in: you can get known good corlibs with mscorlib.dll and others for the unity version you want.

One detail however: there's a known issue where the data miner doesn't get corlibs set that works for old mono when:
- It is available, but not the only mono like in 2018.x versions
- It is the only runtime available (I encountered this on 5.5.4f1 where I had to install it to get the proper corlibs set and the website above had I presume the editor's corlibs which aren't useful since we want the player builds's corlibs)

But this can be fixed at a later time. I at least know new mono has proper corlibs and are known to work better than melons's set. In theory, this pr could be a reason to drop NetStandardPatches were it not for System.Drawing, but I rather not risk it and keep it as a falback solution, just in case. It could be revised in universality.