### PR TITLE
Fix 2 issues related to mono linux native game not booting

### DIFF
--- a/MelonLoader.Bootstrap/LinuxEntry/LinuxEntry.cpp
+++ b/MelonLoader.Bootstrap/LinuxEntry/LinuxEntry.cpp
@@ -15,10 +15,14 @@ PlayerMain original;
 
 void detour(int a, char **b)
 {
-    Dl_info dl_info;
-    dladdr(reinterpret_cast<void*>(detour), &dl_info);
+    void *hUnity = dlopen("MelonLoader.Bootstrap.so", RTLD_NOW);
+    if (hUnity == nullptr)
+    {
+        printf("MelonLoader.Bootstrap.so");
+        return;
+    }
 
-    Init(dl_info.dli_fbase);
+    Init(hUnity);
 
     return original(a, b);
 }

--- a/MelonLoader.Bootstrap/RuntimeHandlers/Mono/MonoHandler.cs
+++ b/MelonLoader.Bootstrap/RuntimeHandlers/Mono/MonoHandler.cs
@@ -112,10 +112,14 @@ internal static class MonoHandler
 
         if (Mono is { IsOld: false, DomainSetConfig: not null })
         {
-            MelonDebug.Log("Setting Mono Config");
+            string configFile = $"{Environment.ProcessPath}.config";
+            MelonDebug.Log($"Setting Mono Config paths: base_dir: {Core.GameDir}, config_file_name: {configFile}");
 
-            Mono.DomainSetConfig(Domain, Core.GameDir, name);
+            Mono.DomainSetConfig(Domain, Core.GameDir, configFile);
         }
+        
+        MelonDebug.Log("Parsing default Mono config");
+        Mono.ConfigParse(null);
 
         InitializeManaged();
         jitParseOptionsPatch?.Destroy();

--- a/MelonLoader.Bootstrap/RuntimeHandlers/Mono/MonoLib.cs
+++ b/MelonLoader.Bootstrap/RuntimeHandlers/Mono/MonoLib.cs
@@ -38,6 +38,7 @@ internal class MonoLib
 
     public required ThreadCurrentFn ThreadCurrent { get; init; }
     public required DebugInitFn DebugInit { get; init; }
+    public required ConfigParseFn ConfigParse { get; init; }
     public required ThreadSetMainFn ThreadSetMain { get; init; }
     public required RuntimeInvokeFn RuntimeInvoke { get; init; }
     public required StringNewFn StringNew { get; init; }
@@ -80,6 +81,7 @@ internal class MonoLib
             || !NativeLibrary.TryGetExport(hRuntime, "mono_runtime_invoke", out var runtimeInvokePtr)
             || !NativeLibrary.TryGetExport(hRuntime, "mono_jit_parse_options", out var jitParseOptionsPtr)
             || !NativeLibrary.TryGetExport(hRuntime, "mono_debug_init", out var debugInitPtr)
+            || !NativeFunc.GetExport<ConfigParseFn>(hRuntime, "mono_config_parse", out var configParse)
             || !NativeFunc.GetExport<ThreadCurrentFn>(hRuntime, "mono_thread_current", out var threadCurrent)
             || !NativeFunc.GetExport<ThreadSetMainFn>(hRuntime, "mono_thread_set_main", out var threadSetMain)
             || !NativeFunc.GetExport<StringNewFn>(hRuntime, "mono_string_new", out var stringNew)
@@ -129,7 +131,8 @@ internal class MonoLib
             InstallAssemblyPreloadHook = installAssemblyPreloadHook,
             InstallAssemblySearchHook = installAssemblySearchHook,
             InstallAssemblyLoadHook = installAssemblyLoadHook,
-            DomainSetConfig = domainSetConfig
+            DomainSetConfig = domainSetConfig,
+            ConfigParse = configParse
         };
     }
 
@@ -258,7 +261,10 @@ internal class MonoLib
     public delegate nint DomainAssemblyOpenFn(nint domain, string path);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
-    public delegate void DomainSetConfigFn(nint domain, string configPath, nint name);
+    public delegate void DomainSetConfigFn(nint domain, string configPath, string configFile);
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+    public delegate void ConfigParseFn(string? configPath);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate nint AssemblyPreloadHookFn(ref AssemblyName name, nint assemblyPaths, nint userData);


### PR DESCRIPTION
I need to investigate some more to find out other issues I been seeing, but I am very confident on these 2 for now.

The first one involves some Unity versions (and dootstop) was doing which is you need to have the second parameter be the game's exe suffixed with ".config". Not sure why Unity does this, but after double checking what doorstop was doing using ghidra, this was correct. The biggest thing is it is NECESSARY to call mono_config_parse because not doing that means its config won't be read. Normally, Unity would do this, but it seems that it might not due to our hooking and this matters for linux because many games maps some dll on non windows platform. Specifically, "MonoPosixHelp" has a special mapping which is important because MonoMod.RuntimeDetour needs it to do its detouring (otherwise, it falbacks to what seems to be a broken handler with libc). Not loading the config meant Mono couldn't locate the library, but parsing the config allows it to.

The second issue is p simple: the handle of the bootstrap wasn't fetched correctly. Turns out dlopen works perfectly fine for this.

So far, I am aware of at least 3 other distinct linux native issues that don't happen on bepinex v5 that I need to look into more:
- A 2020.3.44 game is breaking at the end of its initial load with UE installed due to the GC crashing, very unclear what's happening and it seems too hard to get anything for debugging
- A 2021.3.19 game is breaking early on boot due to some weird TypeLoad exception that I need to look into more
- The linux entrypoint is incorrect to assume the presence of a .so file with its symbol

The third one, I'll look into revising the entrypoint model in general because I think I can inspire from what doorstop does

For now, this PR is what I have that are "easy" fixes.