### PR TITLE
Improve the stability of the FileSystemWatcher

### DIFF
--- a/MelonLoader/Core.cs
+++ b/MelonLoader/Core.cs
@@ -199,7 +199,10 @@ namespace MelonLoader
         internal static void Quit()
         {
             MelonDebug.Msg("[ML Core] Received Quit Request! Shutting down...");
-            
+
+            foreach (var prefFile in MelonPreferences.PrefFiles)
+                prefFile.FileWatcher.Destroy();
+            MelonPreferences.DefaultFile.FileWatcher.Destroy();
             MelonPreferences.Save();
 
             HarmonyInstance.UnpatchSelf();


### PR DESCRIPTION
This PR does 2 changes:
- Spin lock on reload so we don't continuously reload at infinite
- Make sure we don't do an extra load on quit by stopping all FileWatcher

The first one specifically is important because it prevented Inscryption to boot on linux since we kept reloading and having the file watcher reload....and it kept going like that without much happening.

As a sidenote: this behavior of receiving multiple events (possibly from different worker threads) is a known behavior of the FileSystemWatcher so while this fix works, it needs to be kept in mind that it's possible to race here, but the spin lock should hopefully prevent these and only reload once per write.