### PR TITLE
Change Bootstrap to only use plt hooks as native detouring method

### DIFF
--- a/MelonLoader.Bootstrap/LibcNative.cs
+++ b/MelonLoader.Bootstrap/LibcNative.cs
@@ -21,6 +21,10 @@ internal partial class LibcNative
         nint rtLdFini,
         nint stackEnd);
 
+    [LibraryImport("libc", EntryPoint = "dlsym", StringMarshalling = StringMarshalling.Utf8)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial nint Dlsym(nint handle, string symbol);
+
     [LibraryImport("libc", EntryPoint = "setenv", StringMarshalling = StringMarshalling.Utf8)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial int Setenv(string name, string value,[MarshalAs(UnmanagedType.Bool)] bool overwrite);

--- a/MelonLoader.Bootstrap/WindowsNative.cs
+++ b/MelonLoader.Bootstrap/WindowsNative.cs
@@ -10,6 +10,10 @@ internal static partial class WindowsNative
     internal const uint StdOutputHandle = 4294967285;
     internal const uint StdErrorHandle = 4294967284;
 
+    [LibraryImport("kernel32.dll", EntryPoint = "GetProcAddress", StringMarshalling = StringMarshalling.Utf8)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvStdcall)])]
+    internal static partial nint GetProcAddress(nint hModule, string lpProcName);
+
     [LibraryImport("kernel32.dll")]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvStdcall)])]
     internal static partial nint GetStdHandle(uint nStdHandle);


### PR DESCRIPTION
This PR changes the main native detouring method of the bootstrap to use plt hooks rather than Dobby.

I alluded as to why plt hooks is better for the bootstrap in a previous pr, but the summary is the hooks are much more targeted and more precise than Dobby. This brings a few advantages:
- Dobby has some strange instabilities problems that I never experienced with plt hooks such as the fact that if you try to boot a game with a mono built yourself, it will corrupt mono. Another one was that on linux, it could corrupt memory, but that only happened with more recent versions than the one in the project (not quite sure why the one we have is fine, but it still felt problematic to me).
- We only hook on the calls unity does to the symbols rather than changing the code of the symbols themselves. This is less prone to problems because we're essentially changing a pointer to a function rather than detouring one with some allocated jump tables
- It allows us to safely hook system functions and the one that's very interesting here is dlsym because unity obviously needs to call mono / il2cpp init so it had to load the symbols via dlsym. This becomes more powerful because it allows us to return a DIFFERENT address (our own) as the symbol which gives us pretty discrete hooks on anything unity might want to do with mono / il2cpp
- Due to the above, there's no longer any need to have heuristics about where mono might be located: unity called dlsym for us with a handle! It's not even needed to check the filename to determine if it's old mono because mono_jit_init_version already gave us that info

The size of the PR is mostly the refactors I needed to do to make this work, but it notably simplified the logic especially on the mono side of things.

I tested on mono (old / new) and il2cpp on Windows / Linux in both x64 and x86 runtime. I didn't see any problems with the bootstrapping stages.