### PR TITLE
Symbols debugging improvements

### DIFF
--- a/Dependencies/CompatibilityLayers/Demeo/Demeo.csproj
+++ b/Dependencies/CompatibilityLayers/Demeo/Demeo.csproj
@@ -5,7 +5,7 @@
         <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
         <OutputPath>$(MLOutDir)/MelonLoader/Dependencies/CompatibilityLayers</OutputPath>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <DebugType>embedded</DebugType>
+        <DebugType>portable</DebugType>
     </PropertyGroup>
     <ItemGroup>
         <ProjectReference Include="..\..\..\MelonLoader\MelonLoader.csproj" Private="false" />

--- a/Dependencies/CompatibilityLayers/IPA/IPA.csproj
+++ b/Dependencies/CompatibilityLayers/IPA/IPA.csproj
@@ -5,7 +5,7 @@
         <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
         <OutputPath>$(MLOutDir)/MelonLoader/Dependencies/CompatibilityLayers</OutputPath>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <DebugType>embedded</DebugType>
+        <DebugType>portable</DebugType>
     </PropertyGroup>
     <ItemGroup>
         <ProjectReference Include="..\..\..\MelonLoader\MelonLoader.csproj" Private="false" />

--- a/Dependencies/CompatibilityLayers/Muse_Dash_Mono/Muse_Dash_Mono.csproj
+++ b/Dependencies/CompatibilityLayers/Muse_Dash_Mono/Muse_Dash_Mono.csproj
@@ -5,7 +5,7 @@
         <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
         <OutputPath>$(MLOutDir)/MelonLoader/Dependencies/CompatibilityLayers</OutputPath>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <DebugType>embedded</DebugType>
+        <DebugType>portable</DebugType>
     </PropertyGroup>
     <ItemGroup>
         <ProjectReference Include="..\..\..\MelonLoader\MelonLoader.csproj" Private="false" />

--- a/Dependencies/MelonStartScreen/MelonStartScreen.csproj
+++ b/Dependencies/MelonStartScreen/MelonStartScreen.csproj
@@ -6,7 +6,7 @@
         <OutputPath>$(MLOutDir)/MelonLoader</OutputPath>
         <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <DebugType>embedded</DebugType>
+        <DebugType>portable</DebugType>
     </PropertyGroup>
     <ItemGroup>
         <EmbeddedResource Include="Resources\Loading_Lemon.dat" />

--- a/Dependencies/SupportModules/Mono/Mono.csproj
+++ b/Dependencies/SupportModules/Mono/Mono.csproj
@@ -5,7 +5,7 @@
         <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
         <OutputPath>$(MLOutDir)/MelonLoader/Dependencies/SupportModules</OutputPath>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <DebugType>embedded</DebugType>
+        <DebugType>portable</DebugType>
     </PropertyGroup>
     <ItemGroup>
         <Reference Include="UnityEngine" HintPath="Libs\UnityEngine.dll" Private="False" />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -38,5 +38,19 @@
     <PropertyGroup>
         <MLOutDir>$(SolutionDir)/Output/$(Configuration)/$(RuntimeIdentifier)</MLOutDir>
     </PropertyGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net35'">
+        <ProjectReference Include="$(SolutionDir)/PortablePdbToMdb/PortablePdbToMdb.csproj"
+                          ReferenceOutputAssembly="false"
+                          SkipGetTargetFrameworkProperties="true"
+                          GlobalPropertiesToRemove="TargetFramework" />
+    </ItemGroup>
+    <UsingTask TaskName="PortablePdbToMdb"
+               Condition="'$(TargetFramework)' == 'net35'"
+               AssemblyFile="$(SolutionDir)/PortablePdbToMdb/bin/PortablePdbToMdb.dll"
+               TaskFactory="TaskHostFactory" />
+    <Target Name="SymbolsConvert" Condition="'$(TargetFramework)' == 'net35'" AfterTargets="AfterBuild">
+        <PortablePdbToMdb AssemblyPath="$(TargetPath)" />
+    </Target>
 </Project>
   

--- a/MelonLoader.Bootstrap/Core.cs
+++ b/MelonLoader.Bootstrap/Core.cs
@@ -81,12 +81,8 @@ public static class Core
 
         LoaderConfig.Current.Loader.BaseDirectory = baseDir;
 
-#if DEBUG
-        LoaderConfig.Current.Loader.DebugMode = true;
-#else
         if (ArgParser.IsDefined("melonloader.debug"))
             LoaderConfig.Current.Loader.DebugMode = true;
-#endif
 
         if (ArgParser.IsDefined("--melonloader.captureplayerlogs"))
             LoaderConfig.Current.Loader.CapturePlayerLogs = true;

--- a/MelonLoader.sln
+++ b/MelonLoader.sln
@@ -65,6 +65,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnityEngine.Il2CppAssetBund
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnityEngine.Il2CppImageConversionManager", "UnityUtilities\UnityEngine.Il2CppImageConversionManager\UnityEngine.Il2CppImageConversionManager.csproj", "{8D271ABF-209A-4AF9-8C62-EF92806B7DC1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PortablePdbToMdb", "PortablePdbToMdb\PortablePdbToMdb.csproj", "{90832409-6D54-445D-9310-DCE81F0BB991}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x86 = Debug|x86
@@ -173,6 +175,14 @@ Global
 		{8D271ABF-209A-4AF9-8C62-EF92806B7DC1}.Release|x64.Build.0 = Release|x64
 		{8D271ABF-209A-4AF9-8C62-EF92806B7DC1}.Release|x86.ActiveCfg = Release|x86
 		{8D271ABF-209A-4AF9-8C62-EF92806B7DC1}.Release|x86.Build.0 = Release|x86
+		{90832409-6D54-445D-9310-DCE81F0BB991}.Debug|x86.ActiveCfg = Debug|x86
+		{90832409-6D54-445D-9310-DCE81F0BB991}.Debug|x86.Build.0 = Debug|x86
+		{90832409-6D54-445D-9310-DCE81F0BB991}.Debug|x64.ActiveCfg = Debug|x64
+		{90832409-6D54-445D-9310-DCE81F0BB991}.Release|x86.ActiveCfg = Release|x86
+		{90832409-6D54-445D-9310-DCE81F0BB991}.Release|x86.Build.0 = Release|x86
+		{90832409-6D54-445D-9310-DCE81F0BB991}.Release|x64.ActiveCfg = Release|x64
+		{90832409-6D54-445D-9310-DCE81F0BB991}.Release|x64.Build.0 = Release|x64
+		{90832409-6D54-445D-9310-DCE81F0BB991}.Debug|x64.Build.0 = Debug|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/MelonLoader/MelonLoader.csproj
+++ b/MelonLoader/MelonLoader.csproj
@@ -7,7 +7,7 @@
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <EnableDynamicLoading>true</EnableDynamicLoading>
-        <DebugType>embedded</DebugType>
+        <DebugType>portable</DebugType>
         <IsPackable>true</IsPackable>
         <PackageId>LavaGang.MelonLoader</PackageId>
         <PackageTags>modding unity</PackageTags>

--- a/PortablePdbToMdb/PortablePdbToMdb.cs
+++ b/PortablePdbToMdb/PortablePdbToMdb.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Mono.Cecil;
+using Mono.Cecil.Mdb;
+
+namespace PortablePdbToMdb;
+
+public class PortablePdbToMdb : Task
+{
+    [Required]
+    public string? AssemblyPath { get; set; }
+    
+    public override bool Execute()
+    {
+        try
+        {
+            var module = ModuleDefinition.ReadModule(AssemblyPath, new()
+            {
+                ReadSymbols =  true,
+            });
+
+            var allMethod = module.GetTypes().SelectMany(x => x.Methods);
+            var writerProvider = new MdbWriterProvider();
+            using (var writer = writerProvider.GetSymbolWriter(module, AssemblyPath))
+            {
+                foreach (MethodDefinition methodDefinition in allMethod)
+                    writer.Write(methodDefinition.DebugInformation);
+            }
+        }
+        catch (Exception e)
+        {
+            Log.LogError(e.Message);
+            return false;
+        }
+
+        string mdbPath = AssemblyPath + ".mdb";
+        if (File.Exists(mdbPath))
+            Log.LogMessage(MessageImportance.High, $"Mdb file created successfully at {mdbPath}");
+        return true;
+    }
+}

--- a/PortablePdbToMdb/PortablePdbToMdb.csproj
+++ b/PortablePdbToMdb/PortablePdbToMdb.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <LangVersion>latest</LangVersion>
+        <Nullable>enable</Nullable>
+        <PlatformTarget>AnyCpu</PlatformTarget>
+        <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+        <OutputPath>$(MSBuildProjectDirectory)/bin</OutputPath>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.13.9" />
+      <PackageReference Include="Mono.Cecil" Version="0.11.6" />
+    </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This pr mainly aims to improve (or sometime make work) managed debugging on mono and overall improve debugging. The pr does 3 changes:

1. Make it so debug build don't force the debug mode setting to on, but leave its default to true. This annoyed me a lot because it meant you couldn't test turning off debug mode in debug builds. The default being true is fine for debug builds, but it shouldn't be forced
2. Change every projects susceptible to be loaded by mono to emit symbols in portable flavor instead of embedded. I explain why below
3. Add an MSBuild custom task that kicks on on post build to convert any portable pdb we emit to their mdb equivalent. I explain why below. Sidenote: I think the way I had to do this is a bit jank in MSBuild cause I had to do a project reference that...doesn't reference anything so it forces the assembly to be built before using the task, but I honestly think we might consider moving this to a nuget or something for what I'll explain below

## Explaining symbols format and mono support
So here's the thing about mono and symbols: different mono supports different kinds of format. For our purposes, there's 3 formats of interests:

- mdb (mono's specific symbols format that got deprecated in favor of ppdb)
- portable pdb (aka ppdb)
- embeded pdb (basically the same as ppdb, but embedded inside the assembly instead of being a file)

We don't care about full pdb (the legacy windows only kind) because no mono supports them (I know rider's mono debugger client can load them, but it's not supported and it seems to be specific to Rider so not something worth mentioning).

After a bunch of research, it was known that:
- net35 mono ONLY supports mdb and nothing else. These mono are shipped with any unity 5.x games or older and by default, it's there in 2017.x, but could be changed to the experimental new mono. Between 2018.1 and 2019.1, old mono is still there, but marked deprecated and is no longer the default so it can still appear, but is less likely. Anything 2019.2+ cannot have these monos however
- On net472 mono, but early ones (not quite clear when this changed), only ppdb was supported, but notably, embedded pdb was NOT supported. This meant that even if they are the same format, ppdb should be favored for these mono
- On newer mono than the 2 categories above, ppdb and embedded pdb are supported

So if we want symbols to work during managed debugging, we can't have embedded pdb: it is the worst option next to full because it only supports the newest range of monos. Portable however is better because it essentially supports all of new mono.

We are left with old mono. This is normally tricky because mdb is a legacy format that's no longer used anymore (and the tooling to generate them is long deprecated). The way people traditionally dealt with this is by using a utility called pdb2mdb which could convert the symbols....except that by "pdb", it's FULL pdb, not ppdb. This is problematic for many reasons, but the biggest ones is full pdb can only be emitted on Windows platform so it's not something that works cross platform.

Luckily however, it turns out we can do a ppdb to mdb converter very easily using cecil because it supports all symbols format mentioned above. So to have full range of mono supports, we have everyone emit ppdb and then run an MSBuild task that will emit a separate mdb file. Since these files can't conflict with each other (for a given mono, one or the other supported), it's fine to just have both symbols file present so any debugging sessions work no matter the mono version.

## About mods's symbols
This fixes OUR assemblies, but where it gets tricky is what can we do about mods? I think we would simply advise to emit portable pdb, but what about mdb? This is where I feel like we might consider having this ms build task in a nuget somewhere so mods could import it and use it.

We could also try to emit the file if possible right before the assembly gets loaded, but this is where it felt a bit complex for a simple pr to improve melon's symbols so I stopped it there. Food for thoughts basically.