### PR TITLE
Add a fix for TermInfoReader to prevent throws on boot

### DIFF
--- a/MelonLoader/Fixes/XTermFix.cs
+++ b/MelonLoader/Fixes/XTermFix.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection.Emit;
+using HarmonyLib;
+
+namespace MelonLoader.Fixes;
+
+internal static class XTermFix
+{
+    private static int _intOffset;
+
+    internal static void Install()
+    {
+        if (AccessTools.Method("System.TermInfoReader:DetermineVersion") != null)
+            // Fix has been applied officially
+            return;
+
+        Core.HarmonyInstance.Patch(AccessTools.Method("System.TermInfoReader:ReadHeader"),
+            new HarmonyMethod(typeof(XTermFix), nameof(ReadHeaderPrefix)));
+
+        Core.HarmonyInstance.Patch(AccessTools.Method("System.TermInfoReader:Get", [AccessTools.TypeByName("System.TermInfoNumbers")
+            ]), transpiler: new HarmonyMethod(typeof(XTermFix), nameof(GetTermInfoNumbersTranspiler)));
+
+        Core.HarmonyInstance.Patch(AccessTools.Method("System.TermInfoReader:Get", [AccessTools.TypeByName("System.TermInfoStrings")
+            ]), transpiler: new HarmonyMethod(typeof(XTermFix), nameof(GetTermInfoStringsTranspiler)));
+
+        Core.HarmonyInstance.Patch(AccessTools.Method("System.TermInfoReader:GetStringBytes", [AccessTools.TypeByName("System.TermInfoStrings")
+            ]), transpiler: new HarmonyMethod(typeof(XTermFix), nameof(GetTermInfoStringsTranspiler)));
+    }
+
+    private static int GetInt32(byte[] buffer, int offset)
+    {
+        int b1 = buffer[offset];
+        int b2 = buffer[offset + 1];
+        int b3 = buffer[offset + 2];
+        int b4 = buffer[offset + 3];
+
+        return b1 | (b2 << 8) | (b3 << 16) | (b4 << 24);
+    }
+
+    private static short GetInt16(byte[] buffer, int offset)
+    {
+        int b1 = buffer[offset];
+        int b2 = buffer[offset + 1];
+
+        return (short) (b1 | (b2 << 8));
+    }
+
+    public static int GetInteger(byte[] buffer, int offset) =>
+        _intOffset == 2
+            ? GetInt16(buffer, offset)
+            : GetInt32(buffer, offset);
+
+    private static void DetermineVersion(short magic)
+    {
+        _intOffset = magic switch
+        {
+            0x11a => 2,
+            0x21e => 4,
+            _ => throw new Exception($"Unknown xterm header format: {magic}")
+        };
+    }
+
+    public static bool ReadHeaderPrefix(byte[] buffer,
+                                        ref int position,
+                                        ref short ___boolSize,
+                                        ref short ___numSize,
+                                        ref short ___strOffsets)
+    {
+        MelonDebug.Msg("Reading header");
+        var magic = GetInt16(buffer, position);
+        position += 2;
+        DetermineVersion(magic);
+
+        // nameSize = GetInt16(buffer, position);
+        position += 2;
+        ___boolSize = GetInt16(buffer, position);
+        position += 2;
+        ___numSize = GetInt16(buffer, position);
+        position += 2;
+        ___strOffsets = GetInt16(buffer, position);
+        position += 2;
+        // strSize = GetInt16(buffer, position);
+        position += 2;
+
+        return false;
+    }
+
+    public static IEnumerable<CodeInstruction> GetTermInfoNumbersTranspiler(IEnumerable<CodeInstruction> instructions)
+    {
+        // This implementation does not seem to have changed
+
+        var list = instructions.ToList();
+
+        list[31] = new CodeInstruction(OpCodes.Ldsfld, AccessTools.Field(typeof(XTermFix), nameof(_intOffset)));
+        list[36] = new CodeInstruction(OpCodes.Nop);
+        list[39] = new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(XTermFix), nameof(GetInteger)));
+
+        return list;
+    }
+
+    public static IEnumerable<CodeInstruction> GetTermInfoStringsTranspiler(IEnumerable<CodeInstruction> instructions)
+    {
+        // This implementation does not seem to have changed
+
+        var list = instructions.ToList();
+
+        list[32] = new CodeInstruction(OpCodes.Ldsfld, AccessTools.Field(typeof(XTermFix), nameof(_intOffset)));
+
+        return list;
+    }
+}


### PR DESCRIPTION
This fix is directly taken from bepinex: https://github.com/BepInEx/BepInEx/blob/master/Runtimes/Unity/BepInEx.Unity.Mono.Preloader/RuntimeFixes/XTermFix.cs#L16

It was found to affect melon in a bad way particularly when trying to load UE on old unity mono on linux (seems the fix only was applied on 2020.2). What would happen is a throw early on that prevents the C# console to function. The throw would typically say something like "Magic number is wrong: 542".

You will notice a...really nasty hacky workaround with MonoMod on both this PR and the bepinex version which is that legacy MonoMod will eventually cause the Console cctor to run....which eventually gets the TermInfoReader to kick in. This is bad because it means it gets to kick in unpatched...when we are trying to patch it!

The nasty workaround is to set DetourHelper.Native directly instead of letting MonoMod determine it. Since we use ifdef for this, it's fine, it just looks ugly :(