### PR TITLE
Implement a setting to capture harmony logs

### DIFF
--- a/MelonLoader.Bootstrap/Core.cs
+++ b/MelonLoader.Bootstrap/Core.cs
@@ -137,6 +137,9 @@ public static class Core
         if (ArgParser.IsDefined("--melonloader.captureplayerlogs"))
             LoaderConfig.Current.Loader.CapturePlayerLogs = true;
 
+        if (Enum.TryParse<LoaderConfig.CoreConfig.HarmonyLogVerbosity>(ArgParser.GetValue("--melonloader.harmonyloglevel"), out var harmonyLogLevel))
+            LoaderConfig.Current.Loader.HarmonyLogLevel = harmonyLogLevel;
+
         if (ArgParser.IsDefined("no-mods"))
             LoaderConfig.Current.Loader.Disable = true;
 

--- a/MelonLoader/Core.cs
+++ b/MelonLoader/Core.cs
@@ -152,6 +152,8 @@ namespace MelonLoader
 
 #endif
 
+            HarmonyLogger.Setup();
+
 #if !WINDOWS && !NET6_0_OR_GREATER
             // Using Process.Start can run Console..cctor
             // Since MonoMod's PlatformHelper (used by DetourHelper.Native) runs Process.Start to determine ARM/x86

--- a/MelonLoader/InternalUtils/HarmonyLogger.cs
+++ b/MelonLoader/InternalUtils/HarmonyLogger.cs
@@ -1,0 +1,64 @@
+using HarmonyLib.Tools;
+
+namespace MelonLoader.InternalUtils;
+
+internal static class HarmonyLogger
+{
+    private static readonly Logger.LogChannel[] OrderedLogChannels =
+    [
+        Logger.LogChannel.Error,
+        Logger.LogChannel.Warn,
+        Logger.LogChannel.Info,
+        Logger.LogChannel.Debug
+    ];
+
+    internal static void Setup()
+    {
+        Logger.ChannelFilter = DetermineChannelFilter(LoaderConfig.Current.Loader.HarmonyLogLevel);
+        Logger.MessageReceived += LoggerOnMessageReceived;
+    }
+
+    private static void LoggerOnMessageReceived(object sender, Logger.LogEventArgs e)
+    {
+        switch (e.LogChannel)
+        {
+            case Logger.LogChannel.Info:
+            case Logger.LogChannel.IL:
+            case Logger.LogChannel.Debug:
+                MelonLogger.Msg(e.Message);
+                break;
+            case Logger.LogChannel.Warn:
+                MelonLogger.Warning(e.Message);
+                break;
+            case Logger.LogChannel.Error:
+                MelonLogger.Error(e.Message);
+                break;
+        }
+    }
+
+    private static Logger.LogChannel DetermineChannelFilter(LoaderConfig.CoreConfig.HarmonyLogVerbosity channel)
+    {
+        if (channel == LoaderConfig.CoreConfig.HarmonyLogVerbosity.IL)
+            return Logger.LogChannel.All;
+        if (channel == LoaderConfig.CoreConfig.HarmonyLogVerbosity.None)
+            return Logger.LogChannel.None;
+
+        Logger.LogChannel channelFilter = Logger.LogChannel.None;
+        foreach (var logChannel in OrderedLogChannels)
+        {
+            channelFilter |= logChannel;
+            Logger.LogChannel newChannel = channel switch
+            {
+                LoaderConfig.CoreConfig.HarmonyLogVerbosity.Error => Logger.LogChannel.Error,
+                LoaderConfig.CoreConfig.HarmonyLogVerbosity.Warn => Logger.LogChannel.Warn,
+                LoaderConfig.CoreConfig.HarmonyLogVerbosity.Info => Logger.LogChannel.Info,
+                LoaderConfig.CoreConfig.HarmonyLogVerbosity.Debug => Logger.LogChannel.Debug,
+                _ => Logger.LogChannel.None
+            };
+            if (logChannel == newChannel)
+                break;
+        }
+
+        return channelFilter;
+    }
+}

--- a/MelonLoader/LoaderConfig.cs
+++ b/MelonLoader/LoaderConfig.cs
@@ -48,6 +48,10 @@ public class LoaderConfig
         [TomlPrecedingComment("Capture all Unity player logs into MelonLoader's logs even if the game disabled them. NOTE: Depending on the game or Unity version, these logs can be overly verbose. Equivalent to the '--melonloader.captureplayerlogs' launch option")]
         public bool CapturePlayerLogs { get; internal set; }
 
+        [TomlProperty("harmony_log_level")]
+        [TomlPrecedingComment("The maximum Harmony log verbosity to capture into MelonLoader's logs. Possible values in verbosity order are: \"None\", \"Error\", \"Warn\", \"Info\", \"Debug\", or \"IL\". Equivalent to the '--melonloader.harmonyloglevel' launch option")]
+        public HarmonyLogVerbosity HarmonyLogLevel { get; internal set; } = HarmonyLogVerbosity.Warn;
+
         [TomlProperty("force_quit")]
         [TomlPrecedingComment("Only use this if the game freezes when trying to quit. Equivalent to the '--quitfix' launch option")]
         public bool ForceQuit { get; internal set; }
@@ -71,7 +75,17 @@ public class LoaderConfig
             Rainbow,
             RandomRainbow,
             Lemon
-        };
+        }
+
+        public enum HarmonyLogVerbosity
+        {
+            None,
+            Info,
+            Warn,
+            Error,
+            Debug,
+            IL
+        }
     }
 
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]

--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ disable = false
 debug_mode = true
 # Capture all Unity player logs into MelonLoader's logs even if the game disabled them. NOTE: Depending on the game or Unity version, these logs can be overly verbose. Equivalent to the '--melonloader.captureplayerlogs' launch option
 capture_player_logs = true
+# The maximum Harmony log verbosity to capture into MelonLoader's logs. Possible values in verbosity order are: "None", "Error", "Warn", "Info", "Debug", or "IL". Equivalent to the '--melonloader.harmonyloglevel' launch option
+harmony_log_level = "Warn"
 # Only use this if the game freezes when trying to quit. Equivalent to the '--quitfix' launch option
 force_quit = false
 # Disables the start screen. Equivalent to the '--melonloader.disablestartscreen' launch option
@@ -203,6 +205,7 @@ enable_cpp2il_native_method_detector = false
 | --melonloader.hidewarnings | Hides Warnings from Displaying |
 | --melonloader.debug | Debug Mode |
 | --melonloader.captureplayerlogs | Capture all Unity player logs into MelonLoader's logs even if the game disabled them. NOTE: Depending on the game or Unity version, these logs can be overly verbose |
+| --melonloader.harmonyloglevel | The maximum Harmony log verbosity to capture into MelonLoader's logs. Possible values in verbosity order are: "None", "Error", "Warn", "Info", "Debug", or "IL" |
 | --melonloader.debugsuspend | Let the Mono debug server wait until a debugger is attached when in Debug Mode (only for Mono games) |
 | --melonloader.debugipaddress | The IP address the Mono debug server will listen to when in Debug Mode (only for Mono games) |
 | --melonloader.debugport | The port the Mono debug server will listen to when in Debug Mode (only for Mono games)       |


### PR DESCRIPTION
This essentially allows to capture harmony's own logs into ours with customizable verbosity.

It's pretty straight forward with the exception of one thing: implementing this revealed how limited our loader config system is.

Ideally, I would have liked to have a list of verbosity we listen for (TOML supports arrays), but this isn't possible. This is because due to the way we're using the loader config, the class needs to be marshalable so we can't have a list. I tried array...but the problem is something goes wrong with nativeaot because it trims the array type which makes it throw when it marshalls and I couldn't find a way to make nativeaot root it (it either isn't possible or there's an issue somewhere with ILC, I couldn't get it to work and gave up with a max verbosity solution instead).

Normally, this could be something I expect we put in our melon preferences since it's only useful on the managed side....but there's several problems with that:
- It now means we have 2 config files which is weird
- We're currently not using any melon preferences so we would need to create one. This isn't a good idea: most mods don't output preferences to their own files so us adding on to the same file people typically uses makes it a bit weird
- The moment we load preferences is too late and wouldn't catch everything

So if anything, implementing this reveals that our config system is p limited and maybe we should consider revising it. For now, this pr is still good enough as is, it's just not as flexible as I would have wanted.

About the default being Warn, in practice, it doesn't log anything except if something went wrong with harmony patching. Info tells you everytime a harmony operation happened which I found p verbose already since we actually do a lot on boot, Debug seems to only add a few not as important lines, but it's not used much. IL is of course the maximum: ALL the IL of patches are dumped which is very useful for debugging complex transpilers.