### PR TITLE
Prevent the GC from collecting plt hooks delegates

### DIFF
--- a/MelonLoader.Bootstrap/Logging/ConsoleHandler.cs
+++ b/MelonLoader.Bootstrap/Logging/ConsoleHandler.cs
@@ -12,11 +12,13 @@ internal static class ConsoleHandler
 
     [UnmanagedFunctionPointer(CallingConvention.StdCall)]
     private delegate int CloseHandleFn(uint hObject);
+    private static readonly CloseHandleFn HookCloseHandleDelegate = HookCloseHandle;
 #endif
 
 #if LINUX
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     private delegate int FCloseFn(nint stream);
+    private static readonly FCloseFn HookFCloseDelegate = HookFClose;
 #endif
 
     public static bool IsOpen { get; private set; }
@@ -51,14 +53,14 @@ internal static class ConsoleHandler
 #if LINUX
         PltHook.InstallHooks(
         [
-            ("fclose", Marshal.GetFunctionPointerForDelegate<FCloseFn>(HookFClose))
+            ("fclose", Marshal.GetFunctionPointerForDelegate(HookFCloseDelegate))
         ]);
 #endif
 
 #if WINDOWS
         PltHook.InstallHooks(
         [
-            ("CloseHandle", Marshal.GetFunctionPointerForDelegate<CloseHandleFn>(HookCloseHandle)),
+            ("CloseHandle", Marshal.GetFunctionPointerForDelegate(HookCloseHandleDelegate)),
         ]);
         
         Console.SetOut(new StreamWriter(Console.OpenStandardOutput()) { AutoFlush = true });

--- a/MelonLoader.Bootstrap/Logging/LinuxPlayerLogsMirroring.cs
+++ b/MelonLoader.Bootstrap/Logging/LinuxPlayerLogsMirroring.cs
@@ -17,6 +17,11 @@ internal static class LinuxPlayerLogsMirroring
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     private delegate int Dup2Fn(int oldFd, int newFd);
+
+    private static readonly Fopen64Fn HookFopen64Delegate = HookFopen64;
+    private static readonly VfprintfFn HookVfprintfDelegate = HookVfprintf;
+    private static readonly VfprintfChkFn HookVfprintfChkDelegate = HookVfprintfChk;
+    private static readonly Dup2Fn HookDup2Delegate = HookDup2;
     
     private static bool _foundPlayerLogsStream;
     private static nint _streamPlayerLogs = IntPtr.Zero;
@@ -27,10 +32,10 @@ internal static class LinuxPlayerLogsMirroring
     {
         PltHook.InstallHooks(
         [
-            ("fopen64", Marshal.GetFunctionPointerForDelegate<Fopen64Fn>(HookFopen64)),
-            ("vfprintf", Marshal.GetFunctionPointerForDelegate<VfprintfFn>(HookVfprintf)),
-            ("__vfprintf_chk", Marshal.GetFunctionPointerForDelegate<VfprintfChkFn>(HookVfprintfChk)),
-            ("dup2", Marshal.GetFunctionPointerForDelegate<Dup2Fn>(HookDup2))
+            ("fopen64", Marshal.GetFunctionPointerForDelegate(HookFopen64Delegate)),
+            ("vfprintf", Marshal.GetFunctionPointerForDelegate(HookVfprintfDelegate)),
+            ("__vfprintf_chk", Marshal.GetFunctionPointerForDelegate(HookVfprintfChkDelegate)),
+            ("dup2", Marshal.GetFunctionPointerForDelegate(HookDup2Delegate))
         ]);
     }
 

--- a/MelonLoader.Bootstrap/Logging/WindowsPlayerLogsMirroring.cs
+++ b/MelonLoader.Bootstrap/Logging/WindowsPlayerLogsMirroring.cs
@@ -19,6 +19,9 @@ internal static class WindowsPlayerLogsMirroring
         int dwFlagsAndAttributes,
         nint hTemplateFile);
 
+    private static readonly CreateFileWFn HookCreateFileWDelegate = HookCreateFileW;
+    private static readonly WriteFileFn HookWriteFileDelegate = HookWriteFile;
+    
     private static bool _foundPlayerLogsHandle;
     private static nint _logHandle;
     
@@ -28,8 +31,8 @@ internal static class WindowsPlayerLogsMirroring
     {
         PltHook.InstallHooks(
         [
-            ("CreateFileW", Marshal.GetFunctionPointerForDelegate<CreateFileWFn>(HookCreateFileW)),
-            ("WriteFile", Marshal.GetFunctionPointerForDelegate<WriteFileFn>(HookWriteFile))
+            ("CreateFileW", Marshal.GetFunctionPointerForDelegate(HookCreateFileWDelegate)),
+            ("WriteFile", Marshal.GetFunctionPointerForDelegate(HookWriteFileDelegate))
         ]);
     }
 


### PR DESCRIPTION
While testing WIP changes to the resolver, I came across a p nasty issue: it was possible the GC could collect our plt hooks delegates. This is bad because it means that if the GC has a particular stress causing it to run and then unity calls one of our hook, it would crash because the delegate backing the plt hook was collected.

While I only experienced it with the mono_image_open_data_with_name one, just to be safe, I put a thing for all of them which is just keep a static field ref to the delegate and use that one instead when hooking.