### PR TITLE
Make the launch_debugger option wait for a debugger on non Windows platforms

### DIFF
--- a/MelonLoader/Core.cs
+++ b/MelonLoader/Core.cs
@@ -127,8 +127,15 @@ namespace MelonLoader
 
             if (LoaderConfig.Current.Loader.LaunchDebugger && MelonEnvironment.IsDotnetRuntime)
             {
+#if WINDOWS
                 MelonLogger.Msg("[Init] User requested debugger, attempting to launch now...");
                 Debugger.Launch();
+#else
+                MelonLogger.Msg("[Init] User requested to wait until a debugger is attached, waiting now...");
+                while (!Debugger.IsAttached)
+                { }
+                MelonLogger.Msg("[Init] Detected a debugger, resuming initialization...");
+#endif
             }
 
             Environment.SetEnvironmentVariable("IL2CPP_INTEROP_DATABASES_LOCATION", MelonEnvironment.Il2CppAssembliesDirectory);

--- a/MelonLoader/Core.cs
+++ b/MelonLoader/Core.cs
@@ -129,7 +129,13 @@ namespace MelonLoader
             {
 #if WINDOWS
                 MelonLogger.Msg("[Init] User requested debugger, attempting to launch now...");
-                Debugger.Launch();
+                if (Debugger.Launch())
+                {
+                    MelonLogger.Msg("[Init] Done interacting with the debugger launch window, waiting for the debugger to be attached...");
+                    while (!Debugger.IsAttached)
+                    { }
+                    MelonLogger.Msg("[Init] Detected a debugger, resuming initialization...");
+                }
 #else
                 MelonLogger.Msg("[Init] User requested to wait until a debugger is attached, waiting now...");
                 while (!Debugger.IsAttached)

--- a/MelonLoader/LoaderConfig.cs
+++ b/MelonLoader/LoaderConfig.cs
@@ -61,7 +61,7 @@ public class LoaderConfig
         public bool DisableStartScreen { get; internal set; }
 
         [TomlProperty("launch_debugger")]
-        [TomlPrecedingComment("Starts the dotnet debugger (only for Il2Cpp games). Equivalent to the '--melonloader.launchdebugger' launch option")]
+        [TomlPrecedingComment("Starts the dotnet debugger on Windows or wait until one is attached on other OSes (only for Il2Cpp games). Equivalent to the '--melonloader.launchdebugger' launch option")]
         public bool LaunchDebugger { get; internal set; }
 
         [TomlProperty("theme")]

--- a/MelonLoader/LoaderConfig.cs
+++ b/MelonLoader/LoaderConfig.cs
@@ -61,7 +61,7 @@ public class LoaderConfig
         public bool DisableStartScreen { get; internal set; }
 
         [TomlProperty("launch_debugger")]
-        [TomlPrecedingComment("Starts the dotnet debugger on Windows or wait until one is attached on other OSes (only for Il2Cpp games). Equivalent to the '--melonloader.launchdebugger' launch option")]
+        [TomlPrecedingComment("Starts the dotnet debugger on Windows and wait it is attached or just wait until one is attached without launch on other OSes (only for Il2Cpp games). Equivalent to the '--melonloader.launchdebugger' launch option")]
         public bool LaunchDebugger { get; internal set; }
 
         [TomlProperty("theme")]

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ harmony_log_level = "Warn"
 force_quit = false
 # Disables the start screen. Equivalent to the '--melonloader.disablestartscreen' launch option
 disable_start_screen = false
-# Starts the dotnet debugger on Windows or wait until one is attached on other OSes (only for Il2Cpp games). Equivalent to the '--melonloader.launchdebugger' launch option
+# Starts the dotnet debugger on Windows and wait it is attached or just wait until one is attached without launch on other OSes (only for Il2Cpp games). Equivalent to the '--melonloader.launchdebugger' launch option
 launch_debugger = false
 # Sets the loader theme. Currently, the only available themes are "Normal" and "Lemon". Equivalent to the '--melonloader.consolemode' launch option (0 for Normal, 4 for Lemon)
 theme = "Normal"

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ harmony_log_level = "Warn"
 force_quit = false
 # Disables the start screen. Equivalent to the '--melonloader.disablestartscreen' launch option
 disable_start_screen = false
-# Starts the dotnet debugger (only for Il2Cpp games). Equivalent to the '--melonloader.launchdebugger' launch option
+# Starts the dotnet debugger on Windows or wait until one is attached on other OSes (only for Il2Cpp games). Equivalent to the '--melonloader.launchdebugger' launch option
 launch_debugger = false
 # Sets the loader theme. Currently, the only available themes are "Normal" and "Lemon". Equivalent to the '--melonloader.consolemode' launch option (0 for Normal, 4 for Lemon)
 theme = "Normal"


### PR DESCRIPTION
This is pretty simple: the setting was completely useless on any OS other than windows. It's very explicit in the documentation: https://learn.microsoft.com/en-us/dotnet/api/System.Diagnostics.Debugger.Launch?view=net-6.0#remarks

```
Debugger launch is only supported on Windows. On Unix operating systems, the method returns true without launching a debugger.
```

Since the main purpose of this setting is to get a debugger very early on boot, the next best thing is we can simply wait for a debugger to be attached as Debugger.IsAttached is multiplatform.

It effectively makes il2cpp early boot debugging now possible on Linux (and macos once the other PR gets merged) since there was no way to get an attach this early before.