### PR TITLE
Revise and improve the assembly resolver

### DIFF
--- a/MelonLoader.Bootstrap/RuntimeHandlers/Mono/MonoHandler.cs
+++ b/MelonLoader.Bootstrap/RuntimeHandlers/Mono/MonoHandler.cs
@@ -56,7 +56,7 @@ internal static class MonoHandler
         uint newDataLen = (uint)newDataArray.Length;
         fixed (byte* newDataPtr = &newDataArray[0])
         {
-            var newReturn = Mono.ImageOpenFromDataWithName(newDataPtr, newDataLen, needCopy, ref status, refonly, name);
+            var newReturn = Mono.ImageOpenFromDataWithName(newDataPtr, newDataLen, needCopy, ref status, refonly, foundOverridenFile);
             return newReturn;
         }
     }

--- a/MelonLoader.Bootstrap/RuntimeHandlers/Mono/MonoHandler.cs
+++ b/MelonLoader.Bootstrap/RuntimeHandlers/Mono/MonoHandler.cs
@@ -5,8 +5,7 @@ namespace MelonLoader.Bootstrap.RuntimeHandlers.Mono;
 
 internal static class MonoHandler
 {
-    private static nint assemblyManagerResolve;
-    private static nint assemblyManagerLoadInfo;
+    private static nint assemblyManagerSearchAssembly;
     private static bool debugInitCalled;
     private static bool jitInitDone;
 
@@ -190,9 +189,6 @@ internal static class MonoHandler
             return;
         }
 
-        MelonDebug.Log("Adding internal calls");
-        Mono.AddManagedInternalCall<CastManagedAssemblyPtrFn>("MelonLoader.Utils.MonoLibrary::CastManagedAssemblyPtr", CastManagedAssemblyPtrImpl);
-
         var image = Mono.AssemblyGetImage(assembly);
         var interopClass = Mono.ClassFromName(image, "MelonLoader.InternalUtils", "BootstrapInterop");
 
@@ -201,8 +197,7 @@ internal static class MonoHandler
 
         var assemblyManagerClass = Mono.ClassFromName(image, "MelonLoader.Resolver", "AssemblyManager");
 
-        assemblyManagerResolve = Mono.ClassGetMethodFromName(assemblyManagerClass, "Resolve", 6);
-        assemblyManagerLoadInfo = Mono.ClassGetMethodFromName(assemblyManagerClass, "LoadInfo", 1);
+        assemblyManagerSearchAssembly = Mono.ClassGetMethodFromName(assemblyManagerClass, "SearchAssembly", 5);
 
         nint ex = 0;
         MelonDebug.Log("Invoking managed core init");
@@ -215,40 +210,19 @@ internal static class MonoHandler
         Mono.RuntimeInvoke(initMethod, 0, (void**)initArgs, ref ex);
     }
 
-    private static nint CastManagedAssemblyPtrImpl(nint ptr)
-    {
-        return ptr;
-    }
-
     internal static void InstallHooks()
     {
         MelonDebug.Log("Installing hooks");
 
-        Mono.InstallAssemblyHooks(OnAssemblyPreload, OnAssemblySearch, OnAssemblyLoad);
-    }
-
-    private static unsafe void OnAssemblyLoad(nint monoAssembly, nint userData)
-    {
-        if (monoAssembly == 0)
-            return;
-
-        var obj = Mono.AssemblyGetObject(Domain, monoAssembly);
-
-        nint ex = 0;
-        Mono.RuntimeInvoke(assemblyManagerLoadInfo, 0, (void**)&obj, ref ex);
+        Mono.InstallAssemblyHooks(OnAssemblySearch);
     }
 
     private static nint OnAssemblySearch(ref MonoLib.AssemblyName name, nint userData)
     {
-        return ResolveAssembly(name, false);
+        return SearchAssembly(name);
     }
 
-    private static nint OnAssemblyPreload(ref MonoLib.AssemblyName name, nint assemblyPaths, nint userData)
-    {
-        return ResolveAssembly(name, true);
-    }
-
-    private static unsafe nint ResolveAssembly(MonoLib.AssemblyName name, bool preload)
+    private static unsafe nint SearchAssembly(MonoLib.AssemblyName name)
     {
         var args = stackalloc void*[]
         {
@@ -256,14 +230,11 @@ internal static class MonoHandler
             &name.Major,
             &name.Minor,
             &name.Build,
-            &name.Revision,
-            &preload
+            &name.Revision
         };
 
         nint ex = 0;
-        var reflectionAsm = (MonoLib.ReflectionAssembly*)Mono.RuntimeInvoke(assemblyManagerResolve, 0, args, ref ex);
+        var reflectionAsm = (MonoLib.ReflectionAssembly*)Mono.RuntimeInvoke(assemblyManagerSearchAssembly, 0, args, ref ex);
         return reflectionAsm == null ? 0 : reflectionAsm->Assembly;
     }
-
-    private delegate nint CastManagedAssemblyPtrFn(nint ptr);
 }

--- a/MelonLoader/Core.cs
+++ b/MelonLoader/Core.cs
@@ -197,8 +197,8 @@ namespace MelonLoader
             bHapticsManager.Connect(BuildInfo.Name, UnityInformationHandler.GameName);
 
             MelonFolderHandler.ScanForFolders();
-            MelonFolderHandler.LoadMelons(MelonFolderHandler.eScanType.UserLibs);
-            MelonFolderHandler.LoadMelons(MelonFolderHandler.eScanType.Plugins);
+            MelonFolderHandler.LoadMelons(MelonFolderHandler.ScanType.UserLibs);
+            MelonFolderHandler.LoadMelons(MelonFolderHandler.ScanType.Plugins);
 
             MelonEvents.MelonHarmonyEarlyInit.Invoke();
             MelonEvents.OnPreInitialization.Invoke();
@@ -231,7 +231,7 @@ namespace MelonLoader
                 return false;
 
             MelonEvents.OnPreModsLoaded.Invoke();
-            MelonFolderHandler.LoadMelons(MelonFolderHandler.eScanType.Mods);
+            MelonFolderHandler.LoadMelons(MelonFolderHandler.ScanType.Mods);
 
             MelonEvents.OnPreSupportModule.Invoke();
             if (!SupportModule.Setup())

--- a/MelonLoader/Melons/MelonFolderHandler.cs
+++ b/MelonLoader/Melons/MelonFolderHandler.cs
@@ -4,156 +4,155 @@ using System.Collections.Generic;
 using System.IO;
 using MelonLoader.Logging;
 
-namespace MelonLoader.Melons
+namespace MelonLoader.Melons;
+
+internal static class MelonFolderHandler
 {
-    internal static class MelonFolderHandler
+    private static bool _firstSpacer;
+    private static List<string> _userLibDirs = [];
+    private static List<string> _pluginDirs = [];
+    private static List<string> _modDirs = [];
+
+    internal enum ScanType
     {
-        private static bool _firstSpacer;
-        private static List<string> _userLibDirs = [];
-        private static List<string> _pluginDirs = [];
-        private static List<string> _modDirs = [];
+        UserLibs,
+        Plugins,
+        Mods
+    }
 
-        internal enum ScanType
+    internal static void ScanForFolders()
+    {
+        // Add Base Directories to Start of List
+        _userLibDirs.Add(MelonEnvironment.UserLibsDirectory);
+        _pluginDirs.Add(MelonEnvironment.PluginsDirectory);
+        _modDirs.Add(MelonEnvironment.ModsDirectory);
+
+        // Scan Base Folders
+        ScanFolder(ScanType.UserLibs, MelonEnvironment.UserLibsDirectory, ref _userLibDirs, ref _pluginDirs, ref _modDirs);
+        ScanFolder(ScanType.Plugins, MelonEnvironment.PluginsDirectory, ref _userLibDirs, ref _pluginDirs, ref _modDirs);
+        ScanFolder(ScanType.Mods, MelonEnvironment.ModsDirectory, ref _userLibDirs, ref _pluginDirs, ref _modDirs);
+
+        // Add Directories to Resolver
+        foreach (string directory in _userLibDirs)
         {
-            UserLibs,
-            Plugins,
-            Mods
+            MelonUtils.AddNativeDLLDirectory(directory);
+            Resolver.MelonAssemblyResolver.AddSearchDirectory(directory);
         }
-
-        internal static void ScanForFolders()
-        {
-            // Add Base Directories to Start of List
-            _userLibDirs.Add(MelonEnvironment.UserLibsDirectory);
-            _pluginDirs.Add(MelonEnvironment.PluginsDirectory);
-            _modDirs.Add(MelonEnvironment.ModsDirectory);
-
-            // Scan Base Folders
-            ScanFolder(ScanType.UserLibs, MelonEnvironment.UserLibsDirectory, ref _userLibDirs, ref _pluginDirs, ref _modDirs);
-            ScanFolder(ScanType.Plugins, MelonEnvironment.PluginsDirectory, ref _userLibDirs, ref _pluginDirs, ref _modDirs);
-            ScanFolder(ScanType.Mods, MelonEnvironment.ModsDirectory, ref _userLibDirs, ref _pluginDirs, ref _modDirs);
-
-            // Add Directories to Resolver
-            foreach (string directory in _userLibDirs)
-            {
-                MelonUtils.AddNativeDLLDirectory(directory);
-                Resolver.MelonAssemblyResolver.AddSearchDirectory(directory);
-            }
 #if NET6_0_OR_GREATER
-            Resolver.MelonAssemblyResolver.AddSearchDirectory(MelonEnvironment.Il2CppAssembliesDirectory);
+        Resolver.MelonAssemblyResolver.AddSearchDirectory(MelonEnvironment.Il2CppAssembliesDirectory);
 #endif
-            foreach (string directory in _pluginDirs)
-                Resolver.MelonAssemblyResolver.AddSearchDirectory(directory);
-            foreach (string directory in _modDirs)
-                Resolver.MelonAssemblyResolver.AddSearchDirectory(directory);
-        }
+        foreach (string directory in _pluginDirs)
+            Resolver.MelonAssemblyResolver.AddSearchDirectory(directory);
+        foreach (string directory in _modDirs)
+            Resolver.MelonAssemblyResolver.AddSearchDirectory(directory);
+    }
 
-        internal static void LoadMelons(ScanType type)
+    internal static void LoadMelons(ScanType type)
+    {
+        LogStart(type);
+
+        bool hasWroteLine = false;
+        List<MelonAssembly> melonAssemblies = new();
+
+        if (type == ScanType.UserLibs)
+            MelonPreprocessor.LoadFolders(_userLibDirs, false, ref hasWroteLine, ref melonAssemblies);
+
+        int count = melonAssemblies.Count;
+        string typeName = "UserLib".MakePlural(count);
+
+        if (type == ScanType.Plugins)
         {
-            LogStart(type);
-
-            bool hasWroteLine = false;
-            List<MelonAssembly> melonAssemblies = new();
-
-            if (type == ScanType.UserLibs)
-                MelonPreprocessor.LoadFolders(_userLibDirs, false, ref hasWroteLine, ref melonAssemblies);
-
-            int count = melonAssemblies.Count;
-            string typeName = "UserLib".MakePlural(count);
-
-            if (type == ScanType.Plugins)
-            {
-                MelonPreprocessor.LoadFolders(_pluginDirs, true, ref hasWroteLine, ref melonAssemblies);
-                List<MelonPlugin> pluginsLoaded = LoadMelons<MelonPlugin>(melonAssemblies);
-                if (hasWroteLine)
-                    MelonLogger.WriteSpacer();
-                MelonBase.RegisterSorted(pluginsLoaded);
-
-                count = MelonPlugin.RegisteredMelons.Count;
-                typeName = MelonPlugin.TypeName.MakePlural(count);
-            }
-
-            if (type == ScanType.Mods)
-            {
-                MelonPreprocessor.LoadFolders(_modDirs, true, ref hasWroteLine, ref melonAssemblies);
-                List<MelonMod> modsLoaded = LoadMelons<MelonMod>(melonAssemblies);
-                if (hasWroteLine)
-                    MelonLogger.WriteSpacer();
-                MelonBase.RegisterSorted(modsLoaded);
-
-                count = MelonMod.RegisteredMelons.Count;
-                typeName = MelonMod.TypeName.MakePlural(count);
-            }
-
+            MelonPreprocessor.LoadFolders(_pluginDirs, true, ref hasWroteLine, ref melonAssemblies);
+            List<MelonPlugin> pluginsLoaded = LoadMelons<MelonPlugin>(melonAssemblies);
             if (hasWroteLine)
-                MelonLogger.WriteLine(ColorARGB.Magenta);
-            MelonLogger.Msg($"{count} {typeName} loaded.");
-
-            if (_firstSpacer || (type == ScanType.Mods))
                 MelonLogger.WriteSpacer();
-            _firstSpacer = true;
+            MelonBase.RegisterSorted(pluginsLoaded);
+
+            count = MelonPlugin.RegisteredMelons.Count;
+            typeName = MelonPlugin.TypeName.MakePlural(count);
         }
 
-        private static void LogStart(ScanType type)
+        if (type == ScanType.Mods)
         {
-            string typeName = Enum.GetName(typeof(ScanType), type);
-            var loadingMsg = $"Loading {typeName}...";
+            MelonPreprocessor.LoadFolders(_modDirs, true, ref hasWroteLine, ref melonAssemblies);
+            List<MelonMod> modsLoaded = LoadMelons<MelonMod>(melonAssemblies);
+            if (hasWroteLine)
+                MelonLogger.WriteSpacer();
+            MelonBase.RegisterSorted(modsLoaded);
+
+            count = MelonMod.RegisteredMelons.Count;
+            typeName = MelonMod.TypeName.MakePlural(count);
+        }
+
+        if (hasWroteLine)
+            MelonLogger.WriteLine(ColorARGB.Magenta);
+        MelonLogger.Msg($"{count} {typeName} loaded.");
+
+        if (_firstSpacer || (type == ScanType.Mods))
             MelonLogger.WriteSpacer();
-            MelonLogger.Msg(loadingMsg);
-        }
+        _firstSpacer = true;
+    }
 
-        private static List<T> LoadMelons<T>(List<MelonAssembly> melonAssemblies)
-            where T : MelonTypeBase<T>
+    private static void LogStart(ScanType type)
+    {
+        string typeName = Enum.GetName(typeof(ScanType), type);
+        var loadingMsg = $"Loading {typeName}...";
+        MelonLogger.WriteSpacer();
+        MelonLogger.Msg(loadingMsg);
+    }
+
+    private static List<T> LoadMelons<T>(List<MelonAssembly> melonAssemblies)
+        where T : MelonTypeBase<T>
+    {
+        // Load Melons from Assembly
+        foreach (var asm in melonAssemblies)
+            asm.LoadMelons();
+
+        List<T> loadedMelons = new();
+        foreach (var asm in melonAssemblies)
+        foreach (var m in asm.LoadedMelons)
         {
-            // Load Melons from Assembly
-            foreach (var asm in melonAssemblies)
-                asm.LoadMelons();
-
-            List<T> loadedMelons = new();
-            foreach (var asm in melonAssemblies)
-                foreach (var m in asm.LoadedMelons)
-                {
-                    // Validate Type
-                    if (m is T t)
-                    {
-                        loadedMelons.Add(t);
-                        continue;
-                    }
-
-                    // Log Failure
-                    MelonLogger.Warning($"Failed to load Melon '{m.Info.Name}' from '{m.MelonAssembly.Location}': The given Melon is a {m.MelonTypeName} and cannot be loaded as a {MelonTypeBase<T>.TypeName}. Make sure it's in the right folder.");
-                }
-            return loadedMelons;
-        }
-
-        private static void ScanFolder(ScanType scanType,
-            string path,
-            ref List<string> userLibDirectories,
-            ref List<string> pluginDirectories,
-            ref List<string> modDirectories)
-        {
-            // Get Directories
-            string[] directories = Directory.GetDirectories(path, "*", SearchOption.TopDirectoryOnly);
-            if (directories.Length <= 0)
-                return;
-
-            // Parse Directories
-            foreach (var dir in directories)
+            // Validate Type
+            if (m is T t)
             {
-                // Validate Path
-                if (!Directory.Exists(dir))
-                    continue;
-
-                List<string> dirList = scanType switch
-                {
-                    ScanType.UserLibs => userLibDirectories,
-                    ScanType.Plugins => pluginDirectories,
-                    ScanType.Mods => modDirectories,
-                    _ => throw new ArgumentOutOfRangeException(nameof(scanType), scanType, null)
-                };
-
-                dirList.Add(dir);
-                ScanFolder(scanType, dir, ref userLibDirectories, ref pluginDirectories, ref modDirectories);
+                loadedMelons.Add(t);
+                continue;
             }
+
+            // Log Failure
+            MelonLogger.Warning($"Failed to load Melon '{m.Info.Name}' from '{m.MelonAssembly.Location}': The given Melon is a {m.MelonTypeName} and cannot be loaded as a {MelonTypeBase<T>.TypeName}. Make sure it's in the right folder.");
+        }
+        return loadedMelons;
+    }
+
+    private static void ScanFolder(ScanType scanType,
+        string path,
+        ref List<string> userLibDirectories,
+        ref List<string> pluginDirectories,
+        ref List<string> modDirectories)
+    {
+        // Get Directories
+        string[] directories = Directory.GetDirectories(path, "*", SearchOption.TopDirectoryOnly);
+        if (directories.Length <= 0)
+            return;
+
+        // Parse Directories
+        foreach (var dir in directories)
+        {
+            // Validate Path
+            if (!Directory.Exists(dir))
+                continue;
+
+            List<string> dirList = scanType switch
+            {
+                ScanType.UserLibs => userLibDirectories,
+                ScanType.Plugins => pluginDirectories,
+                ScanType.Mods => modDirectories,
+                _ => throw new ArgumentOutOfRangeException(nameof(scanType), scanType, null)
+            };
+
+            dirList.Add(dir);
+            ScanFolder(scanType, dir, ref userLibDirectories, ref pluginDirectories, ref modDirectories);
         }
     }
 }

--- a/MelonLoader/Melons/MelonFolderHandler.cs
+++ b/MelonLoader/Melons/MelonFolderHandler.cs
@@ -143,43 +143,16 @@ namespace MelonLoader.Melons
                 if (!Directory.Exists(dir))
                     continue;
 
-                // Check for Deeper UserLibs
-                string userLibsPath = Path.Combine(dir, "UserLibs");
-                if (Directory.Exists(userLibsPath))
+                List<string> dirList = scanType switch
                 {
-                    userLibDirectories.Add(userLibsPath);
-                    ScanFolder(eScanType.UserLibs, userLibsPath, ref userLibDirectories, ref pluginDirectories, ref modDirectories);
-                }
+                    ScanType.UserLibs => userLibDirectories,
+                    ScanType.Plugins => pluginDirectories,
+                    ScanType.Mods => modDirectories,
+                    _ => throw new ArgumentOutOfRangeException(nameof(scanType), scanType, null)
+                };
 
-                // Is UserLibs Scan?
-                if (scanType == eScanType.UserLibs)
-                    userLibDirectories.Add(dir); // Add to Directories List
-                else
-                {
-                    // Check for Deeper Melon Folder
-                    string melonPath = Path.Combine(dir, "Plugins");
-                    if (Directory.Exists(melonPath))
-                    {
-                        pluginDirectories.Add(melonPath);
-                        ScanFolder(eScanType.Plugins, melonPath, ref userLibDirectories, ref pluginDirectories, ref modDirectories);
-                    }
-
-                    if (scanType == eScanType.Mods)
-                    {
-                        melonPath = Path.Combine(dir, "Mods");
-                        if (Directory.Exists(melonPath))
-                        {
-                            modDirectories.Add(melonPath);
-                            ScanFolder(scanType, melonPath, ref userLibDirectories, ref pluginDirectories, ref modDirectories);
-                        }
-                    }
-
-                    // Add to Directories List
-                    if (scanType == eScanType.Mods)
-                        modDirectories.Add(dir);
-                    else
-                        pluginDirectories.Add(dir);
-                }
+                dirList.Add(dir);
+                ScanFolder(scanType, dir, ref userLibDirectories, ref pluginDirectories, ref modDirectories);
             }
         }
     }

--- a/MelonLoader/Melons/MelonPreprocessor.cs
+++ b/MelonLoader/Melons/MelonPreprocessor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using MelonLoader.Logging;
 using Mono.Cecil;
+using MonoMod.Utils;
 
 namespace MelonLoader.Melons
 {
@@ -16,7 +17,7 @@ namespace MelonLoader.Melons
             // Find All Assemblies
             Dictionary<string, (Version, string)> foundAssemblies = new();
             foreach (string path in directoryPaths)
-                PreprocessFolder(path, ref foundAssemblies);
+                PreprocessFolder(path, ref foundAssemblies, isMelon);
 
             // Load from File Paths
             foreach (var foundFile in foundAssemblies)
@@ -40,7 +41,8 @@ namespace MelonLoader.Melons
         }
 
         private static void PreprocessFolder(string path,
-            ref Dictionary<string, (Version, string)> foundAssemblies)
+            ref Dictionary<string, (Version, string)> foundAssemblies,
+            bool isMelon)
         {
             // Validate Path
             if (!Directory.Exists(path))
@@ -57,6 +59,8 @@ namespace MelonLoader.Melons
                 // Load Definition using Cecil
                 AssemblyDefinition asmDef = LoadDefinition(f);
                 if (asmDef == null)
+                    continue;
+                if (isMelon && !asmDef.HasCustomAttribute(typeof(MelonInfoAttribute).FullName))
                     continue;
 
                 // Pull Name and Version from AssemblyDefinitionName

--- a/MelonLoader/Resolver/AssemblyManager.cs
+++ b/MelonLoader/Resolver/AssemblyManager.cs
@@ -8,85 +8,85 @@ using System.Runtime.Loader;
 
 #pragma warning disable CS8632
 
-namespace MelonLoader.Resolver
+namespace MelonLoader.Resolver;
+
+internal static class AssemblyManager
 {
-    internal static class AssemblyManager
+    private static readonly Dictionary<string, AssemblyResolveInfo> InfoDict = new();
+
+    internal static bool Setup()
     {
-        private static readonly Dictionary<string, AssemblyResolveInfo> InfoDict = new();
+        InstallHooks();
 
-        internal static bool Setup()
+        // Setup all Loaded Assemblies
+        foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
+            LoadInfo(assembly);
+
+        return true;
+    }
+
+    internal static AssemblyResolveInfo GetInfo(string name)
+    {
+        lock (InfoDict)
         {
-            InstallHooks();
-
-            // Setup all Loaded Assemblies
-            foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
-                LoadInfo(assembly);
-
-            return true;
+            if (InfoDict.TryGetValue(name, out AssemblyResolveInfo resolveInfo))
+                return resolveInfo;
+            InfoDict[name] = new AssemblyResolveInfo();
+            return InfoDict[name];
         }
+    }
 
-        internal static AssemblyResolveInfo GetInfo(string name)
-        {
-            lock (InfoDict)
-            {
-                if (InfoDict.TryGetValue(name, out AssemblyResolveInfo resolveInfo))
-                    return resolveInfo;
-                InfoDict[name] = new AssemblyResolveInfo();
-                return InfoDict[name];
-            }
-        }
+    private static Assembly SearchAssembly(string requestedName, Version requestedVersion)
+    {
+        // Get Resolve Information Object
+        AssemblyResolveInfo resolveInfo = GetInfo(requestedName);
 
-        private static Assembly SearchAssembly(string requestedName, Version requestedVersion)
-        {
-            // Get Resolve Information Object
-            AssemblyResolveInfo resolveInfo = GetInfo(requestedName);
+        // Resolve the Information Object
+        Assembly assembly = resolveInfo.Resolve(requestedVersion);
 
-            // Resolve the Information Object
-            Assembly assembly = resolveInfo.Resolve(requestedVersion);
-
-            // Run Passthrough Events
-            if (assembly == null)
-                assembly = MelonAssemblyResolver.SafeInvoke_OnAssemblyResolve(requestedName, requestedVersion);
+        // Run Passthrough Events
+        if (assembly == null)
+            assembly = MelonAssemblyResolver.SafeInvoke_OnAssemblyResolve(requestedName, requestedVersion);
 
 #if NET6_0_OR_GREATER
-            // Search Directories
-            if (assembly == null)
-                assembly = SearchDirectoryManager.Scan(requestedName);
+        // Search Directories
+        if (assembly == null)
+            assembly = SearchDirectoryManager.Scan(requestedName);
 #endif
 
-            // Return
-            return assembly;
-        }
+        // Return
+        return assembly;
+    }
 
-        internal static void LoadInfo(Assembly assembly)
-        {
-            // Get AssemblyName
-            AssemblyName assemblyName = assembly.GetName();
+    internal static void LoadInfo(Assembly assembly)
+    {
+        // Get AssemblyName
+        AssemblyName assemblyName = assembly.GetName();
 
-            // Get Resolve Information Object
-            AssemblyResolveInfo resolveInfo = GetInfo(assemblyName.Name);
+        // Get Resolve Information Object
+        AssemblyResolveInfo resolveInfo = GetInfo(assemblyName.Name);
 
-            // Set Version of Assembly
-            resolveInfo.SetVersionSpecific(assemblyName.Version, assembly);
+        // Set Version of Assembly
+        resolveInfo.SetVersionSpecific(assemblyName.Version, assembly);
 
-            // Run Passthrough Events
-            MelonAssemblyResolver.SafeInvoke_OnAssemblyLoad(assembly);
-        }
+        // Run Passthrough Events
+        MelonAssemblyResolver.SafeInvoke_OnAssemblyLoad(assembly);
+    }
 
-        private static void InstallHooks()
-        {
-            AppDomain.CurrentDomain.AssemblyLoad += OnAppDomainAssemblyLoad;
+    private static void InstallHooks()
+    {
+        AppDomain.CurrentDomain.AssemblyLoad += OnAppDomainAssemblyLoad;
 #if NET6_0_OR_GREATER
-            AssemblyLoadContext.Default.Resolving += Resolve;
+        AssemblyLoadContext.Default.Resolving += Resolve;
 #else
             AppDomain.CurrentDomain.AssemblyResolve += OnAppDomainAssemblyResolve;
             InternalUtils.BootstrapInterop.Library.MonoInstallHooks();
 #endif
-        }
+    }
 
 #if NET6_0_OR_GREATER
-        private static Assembly? Resolve(AssemblyLoadContext alc, AssemblyName name)
-            => SearchAssembly(name.Name, name.Version);
+    private static Assembly? Resolve(AssemblyLoadContext alc, AssemblyName name)
+        => SearchAssembly(name.Name, name.Version);
 #else
         private static Assembly SearchAssembly(string requestedName, ushort major, ushort minor, ushort build, ushort revision)
         {
@@ -101,9 +101,8 @@ namespace MelonLoader.Resolver
         }
 #endif
 
-        private static void OnAppDomainAssemblyLoad(object _, AssemblyLoadEventArgs args)
-        {
-            LoadInfo(args.LoadedAssembly);
-        }
+    private static void OnAppDomainAssemblyLoad(object _, AssemblyLoadEventArgs args)
+    {
+        LoadInfo(args.LoadedAssembly);
     }
 }

--- a/MelonLoader/Resolver/AssemblyManager.cs
+++ b/MelonLoader/Resolver/AssemblyManager.cs
@@ -10,9 +10,9 @@ using System.Runtime.Loader;
 
 namespace MelonLoader.Resolver
 {
-    internal class AssemblyManager
+    internal static class AssemblyManager
     {
-        internal static Dictionary<string, AssemblyResolveInfo> InfoDict = new Dictionary<string, AssemblyResolveInfo>();
+        private static readonly Dictionary<string, AssemblyResolveInfo> InfoDict = new();
 
         internal static bool Setup()
         {
@@ -27,11 +27,13 @@ namespace MelonLoader.Resolver
 
         internal static AssemblyResolveInfo GetInfo(string name)
         {
-            if (InfoDict.TryGetValue(name, out AssemblyResolveInfo resolveInfo))
-                return resolveInfo;
             lock (InfoDict)
+            {
+                if (InfoDict.TryGetValue(name, out AssemblyResolveInfo resolveInfo))
+                    return resolveInfo;
                 InfoDict[name] = new AssemblyResolveInfo();
-            return InfoDict[name];
+                return InfoDict[name];
+            }
         }
 
         private static Assembly Resolve(string requested_name, Version requested_version, bool is_preload)

--- a/MelonLoader/Resolver/AssemblyResolveInfo.cs
+++ b/MelonLoader/Resolver/AssemblyResolveInfo.cs
@@ -2,42 +2,41 @@
 using System.Collections.Generic;
 using System.Reflection;
 
-namespace MelonLoader.Resolver
+namespace MelonLoader.Resolver;
+
+public class AssemblyResolveInfo
 {
-    public class AssemblyResolveInfo
+    public Assembly Override = null;
+    public Assembly Fallback = null;
+    internal Dictionary<Version, Assembly> Versions = new Dictionary<Version, Assembly>();
+
+    internal Assembly Resolve(Version requested_version)
     {
-        public Assembly Override = null;
-        public Assembly Fallback = null;
-        internal Dictionary<Version, Assembly> Versions = new Dictionary<Version, Assembly>();
+        // Check for Override
+        if (Override != null)
+            return Override;
 
-        internal Assembly Resolve(Version requested_version)
-        {
-            // Check for Override
-            if (Override != null)
-                return Override;
+        // Check for Requested Version
+        if (requested_version != null
+            && GetVersionSpecific(requested_version, out Assembly assembly))
+            return assembly;
 
-            // Check for Requested Version
-            if (requested_version != null
-                && GetVersionSpecific(requested_version, out Assembly assembly))
-                return assembly;
+        // Check for Fallback
+        if (Fallback != null)
+            return Fallback;
 
-            // Check for Fallback
-            if (Fallback != null)
-                return Fallback;
-
-            return null;
-        }
-
-        public void SetVersionSpecific(Version version, Assembly assembly = null)
-        {
-            lock (Versions)
-                Versions[version] = assembly;
-        }
-        public Assembly GetVersionSpecific(Version version)
-            => GetVersionSpecific(version, out Assembly assembly)
-                ? assembly
-                : null;
-        public bool GetVersionSpecific(Version version, out Assembly assembly)
-            => Versions.TryGetValue(version, out assembly) && assembly != null;
+        return null;
     }
+
+    public void SetVersionSpecific(Version version, Assembly assembly = null)
+    {
+        lock (Versions)
+            Versions[version] = assembly;
+    }
+    public Assembly GetVersionSpecific(Version version)
+        => GetVersionSpecific(version, out Assembly assembly)
+            ? assembly
+            : null;
+    public bool GetVersionSpecific(Version version, out Assembly assembly)
+        => Versions.TryGetValue(version, out assembly) && assembly != null;
 }

--- a/MelonLoader/Resolver/MelonAssemblyResolver.cs
+++ b/MelonLoader/Resolver/MelonAssemblyResolver.cs
@@ -19,16 +19,7 @@ namespace MelonLoader.Resolver
                 return;
 
             // Setup Search Directories
-            AddSearchDirectories(
-                MelonEnvironment.UserLibsDirectory,
-                MelonEnvironment.PluginsDirectory,
-                MelonEnvironment.ModsDirectory,
-                (MelonUtils.IsGameIl2Cpp()
-                    ? MelonEnvironment.Il2CppAssembliesDirectory
-                    : MelonEnvironment.UnityGameManagedDirectory),
-                MelonEnvironment.OurRuntimeDirectory,
-                MelonEnvironment.MelonBaseDirectory,
-                MelonEnvironment.GameRootDirectory);
+            AddSearchDirectory(MelonEnvironment.OurRuntimeDirectory);
 
             // Setup Redirections
             OverrideBaseAssembly();

--- a/MelonLoader/Resolver/MelonAssemblyResolver.cs
+++ b/MelonLoader/Resolver/MelonAssemblyResolver.cs
@@ -45,27 +45,27 @@ namespace MelonLoader.Resolver
 
         private static void OverrideBaseAssembly()
         {
-            Assembly base_assembly = typeof(MelonAssemblyResolver).Assembly;
-            GetAssemblyResolveInfo(base_assembly.GetName().Name).Override = base_assembly;
-            GetAssemblyResolveInfo("MelonLoader").Override = base_assembly;
-            GetAssemblyResolveInfo("MelonLoader.ModHandler").Override = base_assembly;
+            Assembly baseAssembly = typeof(MelonAssemblyResolver).Assembly;
+            GetAssemblyResolveInfo(baseAssembly.GetName().Name).Override = baseAssembly;
+            GetAssemblyResolveInfo("MelonLoader").Override = baseAssembly;
+            GetAssemblyResolveInfo("MelonLoader.ModHandler").Override = baseAssembly;
         }
 
         private static void ForceResolveRuntime(params string[] fileNames)
         {
-            foreach (string fileName in fileNames)
+            foreach (var fileName in fileNames)
             {
-                string filePath = Path.Combine(MelonEnvironment.OurRuntimeDirectory, fileName);
+                var filePath = Path.Combine(MelonEnvironment.OurRuntimeDirectory, fileName);
                 if (!File.Exists(filePath))
                     return;
 
-                Assembly assembly = null;
+                Assembly assembly;
                 try
                 {
 #if NET6_0_OR_GREATER
                     assembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(filePath);
 #else
-                assembly = Assembly.LoadFrom(filePath);
+                    assembly = Assembly.LoadFrom(filePath);
 #endif
                 }
                 catch { assembly = null; }
@@ -81,13 +81,13 @@ namespace MelonLoader.Resolver
 
         public static void AddSearchDirectories(params string[] directories)
         {
-            foreach (string directory in directories)
+            foreach (var directory in directories)
                 AddSearchDirectory(directory);
         }
 
         public static void AddSearchDirectories(int priority, params string[] directories)
         {
-            foreach (string directory in directories)
+            foreach (var directory in directories)
                 AddSearchDirectory(directory, priority);
         }
 
@@ -129,11 +129,8 @@ namespace MelonLoader.Resolver
         internal static Assembly SafeInvoke_OnAssemblyResolve(string name, Version version)
         {
 #if NET6_0_OR_GREATER
-
             return OnAssemblyResolve?.Invoke(name, version);
-
 #else
-
             // Backwards Compatibility
 #pragma warning disable CS0612 // Type or member is obsolete
             var assembly = InvokeObsoleteOnAssemblyResolve(name, version);
@@ -142,7 +139,6 @@ namespace MelonLoader.Resolver
             if (assembly == null)
                 assembly = OnAssemblyResolve?.Invoke(name, version);
             return assembly;
-
 #endif
         }
 

--- a/MelonLoader/Resolver/SearchDirectoryManager.cs
+++ b/MelonLoader/Resolver/SearchDirectoryManager.cs
@@ -60,23 +60,24 @@ namespace MelonLoader.Resolver
             Sort();
         }
 
-        internal static Assembly Scan(string requested_name)
+        internal static Assembly Scan(string requestedName)
         {
+            MelonDebug.Msg($"[MelonAssemblyResolver] Attempting to find {requestedName}");
             LemonEnumerator<SearchDirectoryInfo> enumerator = new LemonEnumerator<SearchDirectoryInfo>(SearchDirectoryList);
             while (enumerator.MoveNext())
             {
-                string folderpath = enumerator.Current.Path;
-                if (folderpath.ContainsExtension()
-                    || !Directory.Exists(folderpath))
+                string folderPath = enumerator.Current?.Path;
+                if (folderPath.ContainsExtension() || !Directory.Exists(folderPath))
                     continue;
 
-                string filepath = Directory.GetFiles(folderpath).Where(x =>
-                    (!string.IsNullOrEmpty(x)
-                        && ((Path.GetExtension(x).ToLowerInvariant().Equals(".dll")
-                            && Path.GetFileName(x).Equals($"{requested_name}.dll"))
-                        || (Path.GetExtension(x).ToLowerInvariant().Equals(".exe")
-                            && Path.GetFileName(x).Equals($"{requested_name}.exe"))))
-                ).FirstOrDefault();
+                MelonDebug.Msg($"Searching directory {folderPath}");
+                string filepath = 
+                    Directory.GetFiles(folderPath)
+                        .FirstOrDefault(x => !string.IsNullOrEmpty(x) &&
+                                             ((Path.GetExtension(x).ToLowerInvariant().Equals(".dll")
+                                               && Path.GetFileName(x).Equals($"{requestedName}.dll"))
+                                              || (Path.GetExtension(x).ToLowerInvariant().Equals(".exe")
+                                                  && Path.GetFileName(x).Equals($"{requestedName}.exe"))));
 
                 if (string.IsNullOrEmpty(filepath))
                     continue;
@@ -108,7 +109,7 @@ namespace MelonLoader.Resolver
 #endif
             }
 
-            MelonDebug.Msg($"[MelonAssemblyResolver] Failed to find {requested_name} in any of the known search directories");
+            MelonDebug.Msg($"[MelonAssemblyResolver] Failed to find {requestedName} in any of the known search directories");
             return null;
         }
 

--- a/MelonLoader/Resolver/SearchDirectoryManager.cs
+++ b/MelonLoader/Resolver/SearchDirectoryManager.cs
@@ -7,94 +7,93 @@ using System.Reflection;
 using System.Runtime.Loader;
 #endif
 
-namespace MelonLoader.Resolver
+namespace MelonLoader.Resolver;
+
+internal static class SearchDirectoryManager
 {
-    internal static class SearchDirectoryManager
+    private static List<SearchDirectoryInfo> SearchDirectoryList = new List<SearchDirectoryInfo>();
+
+    private static void Sort()
+        => SearchDirectoryList =
+            SearchDirectoryList.OrderBy(x => x.Priority).ToList();
+
+    internal static void Add(string path, int priority = 0)
     {
-        private static List<SearchDirectoryInfo> SearchDirectoryList = new List<SearchDirectoryInfo>();
+        if (string.IsNullOrEmpty(path))
+            return;
 
-        private static void Sort()
-            => SearchDirectoryList =
-                SearchDirectoryList.OrderBy(x => x.Priority).ToList();
+        path = Path.GetFullPath(path);
+        if (path.ContainsExtension())
+            return;
 
-        internal static void Add(string path, int priority = 0)
+        SearchDirectoryInfo searchDirectory = SearchDirectoryList.FirstOrDefault(x => x.Path.Equals(path));
+        if (searchDirectory != null)
+            return;
+
+        searchDirectory = new SearchDirectoryInfo();
+        searchDirectory.Path = path;
+        searchDirectory.Priority = priority;
+        SearchDirectoryList.Add(searchDirectory);
+
+        Sort();
+    }
+
+    internal static void Remove(string path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return;
+
+        path = Path.GetFullPath(path);
+        if (path.ContainsExtension())
+            return;
+
+        SearchDirectoryInfo searchDirectory = SearchDirectoryList.FirstOrDefault(x => x.Path.Equals(path));
+        if (searchDirectory == null)
+            return;
+
+        SearchDirectoryList.Remove(searchDirectory);
+
+        Sort();
+    }
+
+    internal static Assembly Scan(string requestedName)
+    {
+        MelonDebug.Msg($"[MelonAssemblyResolver] Attempting to find {requestedName}");
+        LemonEnumerator<SearchDirectoryInfo> enumerator = new LemonEnumerator<SearchDirectoryInfo>(SearchDirectoryList);
+        while (enumerator.MoveNext())
         {
-            if (string.IsNullOrEmpty(path))
-                return;
+            string folderPath = enumerator.Current?.Path;
+            if (folderPath.ContainsExtension() || !Directory.Exists(folderPath))
+                continue;
 
-            path = Path.GetFullPath(path);
-            if (path.ContainsExtension())
-                return;
+            MelonDebug.Msg($"Searching directory {folderPath}");
+            string filepath = 
+                Directory.GetFiles(folderPath)
+                    .FirstOrDefault(x => !string.IsNullOrEmpty(x) &&
+                                         ((Path.GetExtension(x).ToLowerInvariant().Equals(".dll")
+                                           && Path.GetFileName(x).Equals($"{requestedName}.dll"))
+                                          || (Path.GetExtension(x).ToLowerInvariant().Equals(".exe")
+                                              && Path.GetFileName(x).Equals($"{requestedName}.exe"))));
 
-            SearchDirectoryInfo searchDirectory = SearchDirectoryList.FirstOrDefault(x => x.Path.Equals(path));
-            if (searchDirectory != null)
-                return;
+            if (string.IsNullOrEmpty(filepath))
+                continue;
 
-            searchDirectory = new SearchDirectoryInfo();
-            searchDirectory.Path = path;
-            searchDirectory.Priority = priority;
-            SearchDirectoryList.Add(searchDirectory);
-
-            Sort();
-        }
-
-        internal static void Remove(string path)
-        {
-            if (string.IsNullOrEmpty(path))
-                return;
-
-            path = Path.GetFullPath(path);
-            if (path.ContainsExtension())
-                return;
-
-            SearchDirectoryInfo searchDirectory = SearchDirectoryList.FirstOrDefault(x => x.Path.Equals(path));
-            if (searchDirectory == null)
-                return;
-
-            SearchDirectoryList.Remove(searchDirectory);
-
-            Sort();
-        }
-
-        internal static Assembly Scan(string requestedName)
-        {
-            MelonDebug.Msg($"[MelonAssemblyResolver] Attempting to find {requestedName}");
-            LemonEnumerator<SearchDirectoryInfo> enumerator = new LemonEnumerator<SearchDirectoryInfo>(SearchDirectoryList);
-            while (enumerator.MoveNext())
-            {
-                string folderPath = enumerator.Current?.Path;
-                if (folderPath.ContainsExtension() || !Directory.Exists(folderPath))
-                    continue;
-
-                MelonDebug.Msg($"Searching directory {folderPath}");
-                string filepath = 
-                    Directory.GetFiles(folderPath)
-                        .FirstOrDefault(x => !string.IsNullOrEmpty(x) &&
-                                             ((Path.GetExtension(x).ToLowerInvariant().Equals(".dll")
-                                               && Path.GetFileName(x).Equals($"{requestedName}.dll"))
-                                              || (Path.GetExtension(x).ToLowerInvariant().Equals(".exe")
-                                                  && Path.GetFileName(x).Equals($"{requestedName}.exe"))));
-
-                if (string.IsNullOrEmpty(filepath))
-                    continue;
-
-                MelonDebug.Msg($"[MelonAssemblyResolver] Loading from {filepath}...");
+            MelonDebug.Msg($"[MelonAssemblyResolver] Loading from {filepath}...");
 
 #if NET6_0_OR_GREATER
-                return AssemblyLoadContext.Default.LoadFromAssemblyPath(filepath);
+            return AssemblyLoadContext.Default.LoadFromAssemblyPath(filepath);
 #else
                 return Assembly.LoadFrom(filepath);
 #endif
-            }
-
-            MelonDebug.Msg($"[MelonAssemblyResolver] Failed to find {requestedName} in any of the known search directories");
-            return null;
         }
 
-        private class SearchDirectoryInfo
-        {
-            internal string Path = null;
-            internal int Priority = 0;
-        }
+        MelonDebug.Msg($"[MelonAssemblyResolver] Failed to find {requestedName} in any of the known search directories");
+        return null;
+    }
+
+    private class SearchDirectoryInfo
+    {
+        internal string Path = null;
+        internal int Priority = 0;
     }
 }

--- a/MelonLoader/Resolver/SearchDirectoryManager.cs
+++ b/MelonLoader/Resolver/SearchDirectoryManager.cs
@@ -5,10 +5,6 @@ using System.Reflection;
 
 #if NET6_0_OR_GREATER
 using System.Runtime.Loader;
-#else
-using System;
-using System.Runtime.InteropServices;
-using MelonLoader.Utils;
 #endif
 
 namespace MelonLoader.Resolver
@@ -85,27 +81,9 @@ namespace MelonLoader.Resolver
                 MelonDebug.Msg($"[MelonAssemblyResolver] Loading from {filepath}...");
 
 #if NET6_0_OR_GREATER
-
                 return AssemblyLoadContext.Default.LoadFromAssemblyPath(filepath);
-
 #else
-                IntPtr filePathPtr = Marshal.StringToHGlobalAnsi(filepath);
-                if (filePathPtr == IntPtr.Zero)
-                    continue;
-
-                IntPtr rootPtr = InternalUtils.BootstrapInterop.Library.MonoGetDomainPtr();
-                if (rootPtr == IntPtr.Zero)
-                    continue;
-
-                IntPtr assemblyPtr = MonoLibrary.Instance.mono_assembly_open_full(filePathPtr, IntPtr.Zero, false);
-                if (assemblyPtr == IntPtr.Zero)
-                    continue;
-
-                IntPtr assemblyReflectionPtr = MonoLibrary.Instance.mono_assembly_get_object(rootPtr, assemblyPtr);
-                if (assemblyReflectionPtr == IntPtr.Zero)
-                    continue;
-
-                return MonoLibrary.CastManagedAssemblyPtr(assemblyReflectionPtr);
+                return Assembly.LoadFrom(filepath);
 #endif
             }
 


### PR DESCRIPTION
This pr aims to refactor, redesign, simplify and overall improve our assembly resolver. Originally done because of the issues I pointed out in my previous analysis here: https://gist.github.com/aldelaro5/03990ee04245b3997be5a5c1a07699f8 there's also a bit more stuff in this pr.

The main thing is what I said in the gist: we split the resolver into 2:
- A search hook that may be invoked multiple times for a given assembly, takes priority over the resolver and whose SOLE job is to "fake" the existance of an assembly even if said assembly had been loaded into the domain before. Basically, it allows the redirect feature we already had, but separated in its own search hook
- An actual resolver that uses the regular appdomain event meaning if it gets hit, it means mono itself (and any user specified corlibs folder) couldn't locate the assembly AND that no one wanted to redirect it from the search hook. It only triggers the first time mono can't figure out where an assembly is (meaning at most, 1 call per new assemblies) and this is where we search our known directories to potentially locate the assembly

Other changes as pointed out in the gist is we no longer hook on mono's load because the appdomain load event exist and it was doing the same thing.

This part is relatively straight forward, but this pr also changes a bit how the default directory order is layed out in the resolver. Alongside MANY refactors and cleanup (this code...desperately needed some dusting), the basic idea is the directory scanning logic is very simplified. We ONLY add our runtime folder at first (since it should take priority), but let the directory scanning add directories in traversal order. So essentially, the new order goes:
- Our runtime folder
- UserLibs and any subdirs recursively
- Plugins and any subdirs recursively
- Mods and any subdirs recursively

There is a narrow exception for il2cpp: because the "corlibs" equivalent folder is the il2cppinterop assemblies folder, that one goes second after our runtime folder so it has priority, but it's still possible to override some via the userlibs folder in case of dealing with stripping better. The new directory scanner is much simpler at the traversal of the directories recursively (which is a big part of the deletions in this pr with the other part being simplifying the resolver).

Other than that, this pr brings 2 fixes I encountered while doing this:
- The Image open ... whatever mono hook had a surprising issue that also affected doorstop where if we override the image load (due to corlibs path in the setting), we still passed the original name to the original. This might not seem bad, but it causes a lot of confusion on mono's part because it still thinks the image was loaded in the original location which causes many funsies such as refusing to see the pdb (if it exist) of the overriden location. It also notably can mess up references lookup, but I found that simply passing the overriden path to the original fixes everything
- I found that while melon assembly loading is scanned recursively, it doesn't validate that the managed assembly IS ACTUALLY a melon assembly. This gave me errors with tomlet where it was trying to load it...when we loaded it already for no reasons because it thought it MIGHT BE a melon assembly...but it didn't even have a MelonInfo attribute so this error is kind of misleading. I added a check to just see if the attribute is present (no further checks are needed because the parsing gets done later, we just want to see if it's likely an assembly we care about for preprocessing).

Other than that, that's pretty much it. I split the commits to make reviewing the various cleanups a bit easier cause that part of the codebase definitely needed some love.

However, there is one change I decided not to do in this PR that I want to bring up because I would do it if people agree with it: I REALLY dislike the name of our "AssemblyResolve" event with these changes. This is because the name is very misleading now: it's no longer telling that it's attempting to RESOLVE the assembly, it's more saying an assembly is being SEARCHED. The distinction is important because the appdomain has a Resolve event so it's very easy to confuse the 2, but they do very different things!

I could have said the same about our assembly load event, but I'm more fine here because it ESSENTIALLY does the same job than the appdomain load event now. I think we should rename the AssemblyResolve event though, but the problem is this would be a breaking change.

Is this a change that should be done? Let me know and I'll amend the PR if it's something people agree on.