### PR TITLE
Remove the AllocConsole check for stdout handle

### DIFF
--- a/MelonLoader.Bootstrap/Logging/ConsoleHandler.cs
+++ b/MelonLoader.Bootstrap/Logging/ConsoleHandler.cs
@@ -27,10 +27,9 @@ internal static class ConsoleHandler
     public static void OpenConsole(bool onTop, string? title)
     {
 #if WINDOWS
-        // Do not create a new window if a window already exists or the output is being redirected
+        // Do not create a new window if a window already exists
         var consoleWindow = WindowsNative.GetConsoleWindow();
-        var stdOut = WindowsNative.GetStdHandle(WindowsNative.StdOutputHandle);
-        if (consoleWindow == 0 && stdOut == 0)
+        if (consoleWindow == 0)
         {
             WindowsNative.AllocConsole();
             consoleWindow = WindowsNative.GetConsoleWindow();


### PR DESCRIPTION
I ran into an odd issue with wine/proton, but it appears that it's not consistent on all setup because someone else didn't ran into this problem. Still, when I found out the cause, I was fine to apply this fix.

This is because if the stdout handle was set, well we presumably don't control that case (or at least can't guarantee we control it) so it would mean we would loose our logging. That doesn't make sense, but also, AllocConsole doesn't require this check to work correctly. On my end, if I launch wine/proton without a terminal, the stdout handle is not null. I am not sure why (maybe something wine does?), but what I do know is it makes it POSSIBLE that the handle might not be null while I only launched by double clicking the exe.

So considering this check didn't seem needed by me AND it was known to cause issues on my end, I think we should just remove it to be sure we'll have a console window.