### PR TITLE
Change the TFM of the mdb task to standard 2.0

### DIFF
--- a/PortablePdbToMdb/PortablePdbToMdb.csproj
+++ b/PortablePdbToMdb/PortablePdbToMdb.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>netstandard2.0</TargetFramework>
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
         <PlatformTarget>AnyCpu</PlatformTarget>


### PR DESCRIPTION
net9.0 was causing some local build issues and it's probably better for a task to use this TFM anyway.

This TFM doesn't have the issues on Windows and Linux.