### PR TITLE
Handle Console Close on Windows

### DIFF
--- a/MelonLoader/Core.cs
+++ b/MelonLoader/Core.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Diagnostics;
-using System.Reflection;
-using System.IO;
 using bHapticsLib;
 using System.Threading;
 using MelonLoader.Resolver;
@@ -11,7 +9,6 @@ using MelonLoader.Properties;
 using MelonLoader.Melons;
 
 [assembly: MelonLoader.PatchShield]
-
 #pragma warning disable IDE0051 // Prevent the IDE from complaining about private unreferenced methods
 
 namespace MelonLoader
@@ -49,12 +46,11 @@ namespace MelonLoader
             Fixes.ServerCertificateValidation.Install();
 #endif
 
-
             Assertions.LemonAssertMapping.Setup();
 
             MelonUtils.Setup(AppDomain.CurrentDomain);
             MelonAssemblyResolver.Setup();
-            BootstrapInterop.SetDefaultConsoleTitleWithGameName(UnityInformationHandler.GameName, 
+            BootstrapInterop.SetDefaultConsoleTitleWithGameName(UnityInformationHandler.GameName,
                 UnityInformationHandler.GameVersion);
 
 #if NET6_0_OR_GREATER
@@ -108,6 +104,12 @@ namespace MelonLoader
 #endif
 
             PatchShield.Install();
+            if (MelonUtils.CurrentPlatform == MelonPlatformAttribute.CompatiblePlatforms.WINDOWS_X86
+                || MelonUtils.CurrentPlatform == MelonPlatformAttribute.CompatiblePlatforms.WINDOWS_X64)
+            {
+                Fixes.WindowsUnhandledQuit.Install();
+                MelonEvents.OnUpdate.Subscribe(Fixes.WindowsUnhandledQuit.Update, int.MaxValue);
+            }
 
             MelonPreferences.Load();
 
@@ -162,7 +164,7 @@ namespace MelonLoader
 
             return true;
         }
-        
+
         internal static string GetVersionString()
         {
             var lemon = LoaderConfig.Current.Loader.Theme == LoaderConfig.CoreConfig.LoaderTheme.Lemon;
@@ -171,11 +173,11 @@ namespace MelonLoader
                              $"{(Is_ALPHA_PreRelease ? "ALPHA Pre-Release" : "Open-Beta")}";
             return versionStr;
         }
-        
+
         internal static void WelcomeMessage()
         {
             //if (MelonDebug.IsEnabled())
-                MelonLogger.WriteSpacer();
+            MelonLogger.WriteSpacer();
 
             MelonLogger.MsgDirect("------------------------------");
             MelonLogger.MsgDirect(GetVersionString());
@@ -200,7 +202,7 @@ namespace MelonLoader
         internal static void Quit()
         {
             MelonDebug.Msg("[ML Core] Received Quit Request! Shutting down...");
-            
+
             MelonPreferences.Save();
 
             HarmonyInstance.UnpatchSelf();

--- a/MelonLoader/Fixes/WindowsUnhandledQuit.cs
+++ b/MelonLoader/Fixes/WindowsUnhandledQuit.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace MelonLoader.Fixes
+{
+    internal class WindowsUnhandledQuit
+    {
+        [DllImport("kernel32.dll")]
+        private static extern bool SetConsoleCtrlHandler(
+            IntPtr HandlerRoutine,
+            bool Add);
+
+        private delegate bool HandlerRoutine(int dwCtrlType);
+
+        private static bool SetConsoleCtrlHandler(HandlerRoutine HandlerRoutine, bool Add)
+            => SetConsoleCtrlHandler(HandlerRoutine.GetFunctionPointer(), Add);
+
+        private static bool Exit = false;
+
+        public static void Install()
+        {
+            SetConsoleCtrlHandler((type) =>
+            {
+                if (type == ((int)CtrlType.CTRL_CLOSE_EVENT))
+                {
+                    Exit = true;
+                    while (Exit) Thread.Sleep(200);
+                }
+                return true;
+            }, true);
+        }
+
+        internal static void Update()
+        {
+            if (Exit)
+            {
+                try
+                {
+                    MelonEvents.OnApplicationDefiniteQuit.Invoke();
+                    Core.Quit();
+                }
+                catch (Exception ex)
+                {
+                    MelonLogger.Error("An unexpected error has occurred while cleaning up before closing", ex);
+                }
+                Exit = false;
+            }
+        }
+
+        public enum CtrlType
+        {
+            CTRL_C_EVENT = 0,
+            CTRL_BREAK_EVENT = 1,
+            CTRL_CLOSE_EVENT = 2,
+            CTRL_LOGOFF_EVENT = 5,
+            CTRL_SHUTDOWN_EVENT = 6
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new fix `WindowsUnhandledQuit` which makes sure that when the user closes the console, it gets handled correctly (the OnApplicationDefinitiveQuit gets invoked and Core.Quit gets called).

This is untested on Linux

