### PR TITLE
Add WindowsUnhandledQuit Fix

### DIFF
--- a/MelonLoader/Core.cs
+++ b/MelonLoader/Core.cs
@@ -208,6 +208,13 @@ namespace MelonLoader
 
             PatchShield.Install();
 
+            if (MelonUtils.CurrentPlatform == MelonPlatformAttribute.CompatiblePlatforms.WINDOWS_X86
+                || MelonUtils.CurrentPlatform == MelonPlatformAttribute.CompatiblePlatforms.WINDOWS_X64)
+            {
+                Fixes.WindowsUnhandledQuit.Install();
+                MelonEvents.OnUpdate.Subscribe(Fixes.WindowsUnhandledQuit.Update, int.MaxValue);
+            }
+
             MelonPreferences.Load();
 
             MelonCompatibilityLayer.LoadModules();

--- a/MelonLoader/Fixes/WindowsUnhandledQuit.cs
+++ b/MelonLoader/Fixes/WindowsUnhandledQuit.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace MelonLoader.Fixes
+{
+    internal class WindowsUnhandledQuit
+    {
+        [DllImport("kernel32.dll")]
+        private static extern bool SetConsoleCtrlHandler(
+            IntPtr HandlerRoutine,
+            bool Add);
+
+        private delegate bool HandlerRoutine(int dwCtrlType);
+
+        private static bool SetConsoleCtrlHandler(HandlerRoutine HandlerRoutine, bool Add)
+            => SetConsoleCtrlHandler(HandlerRoutine.GetFunctionPointer(), Add);
+
+        private static bool Exit = false;
+
+        public static void Install()
+        {
+            SetConsoleCtrlHandler((type) =>
+            {
+                if (type == ((int)CtrlType.CTRL_CLOSE_EVENT))
+                {
+                    Exit = true;
+                    while (Exit) Thread.Sleep(200);
+                }
+                return true;
+            }, true);
+        }
+
+        internal static void Update()
+        {
+            if (Exit)
+            {
+                try
+                {
+                    MelonEvents.OnApplicationDefiniteQuit.Invoke();
+                    Core.Quit();
+                }
+                catch (Exception ex)
+                {
+                    MelonLogger.Error("An unexpected error has occurred while cleaning up before closing", ex);
+                }
+                Exit = false;
+            }
+        }
+
+        public enum CtrlType
+        {
+            CTRL_C_EVENT = 0,
+            CTRL_BREAK_EVENT = 1,
+            CTRL_CLOSE_EVENT = 2,
+            CTRL_LOGOFF_EVENT = 5,
+            CTRL_SHUTDOWN_EVENT = 6
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new fix `WindowsUnhandledQuit` which makes sure that when the user closes the console, it gets handled correctly (the OnApplicationDefinitiveQuit gets invoked and Core.Quit() gets called).

Linux is untested.

