### PR TITLE
Add exception logging for mono invokes

### DIFF
--- a/MelonLoader.Bootstrap/RuntimeHandlers/Mono/MonoHandler.cs
+++ b/MelonLoader.Bootstrap/RuntimeHandlers/Mono/MonoHandler.cs
@@ -208,6 +208,13 @@ internal static class MonoHandler
             &bootstrapHandle
         };
         Mono.RuntimeInvoke(initMethod, 0, (void**)initArgs, ref ex);
+        if (ex != 0)
+        {
+            Core.Logger.Error("Failed to invoke the managed init function");
+            var error = Mono.MonoObjectToString(ex);
+            if (error != null)
+                Core.Logger.Error(error);
+        }
     }
 
     internal static void InstallHooks()


### PR DESCRIPTION
Before this, exceptions returned by mono invokes were ignored, which lead to unlogged error messages. This would often happen when the MelonLoader assembly would fail to resolve dependencies due to stripped core assemblies.
This adds proper logging for exceptions returned by mono.