### PR TITLE
Address late code reviews

### DIFF
--- a/MelonLoader.Bootstrap/Core.cs
+++ b/MelonLoader.Bootstrap/Core.cs
@@ -97,18 +97,23 @@ public static class Core
     }
 #endif
 
+#if OSX
+    private static string GetParentDirectory(string path, int level)
+    {
+        string parentPath = path;
+        for (int i = 0; i < level; i++)
+            parentPath = Path.GetDirectoryName(parentPath)!;
+        return parentPath;
+    }
+#endif
+
     [RequiresDynamicCode("Dynamically accesses LoaderConfig properties")]
     private static void InitConfig()
     {
         var customBaseDir = ArgParser.GetValue("melonloader.basedir");
-        var baseDir = 
+        var baseDir = Path.GetDirectoryName(Environment.ProcessPath)!;
 #if OSX
-            Path.GetDirectoryName(
-                Path.GetDirectoryName(
-                    Path.GetDirectoryName(
-                        Path.GetDirectoryName(Process.GetCurrentProcess().MainModule!.FileName)!))!)!;
-#else
-            Path.GetDirectoryName(Process.GetCurrentProcess().MainModule!.FileName)!;
+        baseDir = GetParentDirectory(baseDir, 3);
 #endif
         if (Directory.Exists(customBaseDir))
             baseDir = Path.GetFullPath(customBaseDir);

--- a/MelonLoader.Bootstrap/Core.cs
+++ b/MelonLoader.Bootstrap/Core.cs
@@ -159,10 +159,10 @@ public static class Core
         if (ArgParser.IsDefined("melonloader.debug"))
             LoaderConfig.Current.Loader.DebugMode = true;
 
-        if (ArgParser.IsDefined("--melonloader.captureplayerlogs"))
+        if (ArgParser.IsDefined("melonloader.captureplayerlogs"))
             LoaderConfig.Current.Loader.CapturePlayerLogs = true;
 
-        if (Enum.TryParse<LoaderConfig.CoreConfig.HarmonyLogVerbosity>(ArgParser.GetValue("--melonloader.harmonyloglevel"), out var harmonyLogLevel))
+        if (Enum.TryParse<LoaderConfig.CoreConfig.HarmonyLogVerbosity>(ArgParser.GetValue("melonloader.harmonyloglevel"), out var harmonyLogLevel))
             LoaderConfig.Current.Loader.HarmonyLogLevel = harmonyLogLevel;
 
         if (ArgParser.IsDefined("no-mods"))

--- a/MelonLoader.Bootstrap/Core.cs
+++ b/MelonLoader.Bootstrap/Core.cs
@@ -69,27 +69,10 @@ public static class Core
 #endif
     }
 
-
-    private static readonly Il2CppLib.InitFn Il2CPPInitDetour = Il2CppHandler.InitDetour;
-    private static readonly Il2CppLib.RuntimeInvokeFn InvokeDetour = Il2CppHandler.InvokeDetour;
-    private static readonly MonoLib.JitInitVersionFn MonoInitDetour = MonoHandler.InitDetour;
-    private static readonly MonoLib.JitParseOptionsFn JitParseOptionsDetour = MonoHandler.JitParseOptionsDetour;
-    private static readonly MonoLib.DebugInitFn DebugInitDetour = MonoHandler.DebugInitDetour;
-    private static readonly unsafe MonoLib.ImageOpenFromDataWithNameFn ImageOpenFromDataWithName = MonoHandler.ImageOpenFromDataWithNameDetour;
-
-    private static readonly Dictionary<string, (Action<nint> InitMethod, IntPtr detourPtr)> SymbolRedirects = new()
-    {
-        { "il2cpp_init", (Il2CppHandler.Initialize, Marshal.GetFunctionPointerForDelegate(Il2CPPInitDetour))},
-        { "il2cpp_runtime_invoke", (Il2CppHandler.Initialize, Marshal.GetFunctionPointerForDelegate(InvokeDetour))},
-        { "mono_jit_init_version", (MonoHandler.Initialize, Marshal.GetFunctionPointerForDelegate(MonoInitDetour))},
-        { "mono_jit_parse_options", (MonoHandler.Initialize, Marshal.GetFunctionPointerForDelegate(JitParseOptionsDetour))},
-        { "mono_debug_init", (MonoHandler.Initialize, Marshal.GetFunctionPointerForDelegate(DebugInitDetour))},
-        { "mono_image_open_from_data_with_name", (MonoHandler.Initialize, Marshal.GetFunctionPointerForDelegate(ImageOpenFromDataWithName))}
-    };
-
     private static nint RedirectSymbol(nint handle, string symbolName, nint originalSymbolAddress)
     {
-        if (!SymbolRedirects.TryGetValue(symbolName, out var redirect))
+        if (!MonoHandler.SymbolRedirects.TryGetValue(symbolName, out var redirect)
+            && !Il2CppHandler.SymbolRedirects.TryGetValue(symbolName, out redirect))
             return originalSymbolAddress;
 
         MelonDebug.Log($"Redirecting {symbolName}");

--- a/MelonLoader.Bootstrap/Logging/ColorRGB.cs
+++ b/MelonLoader.Bootstrap/Logging/ColorRGB.cs
@@ -93,7 +93,9 @@ public readonly struct ColorARGB : IEquatable<ColorARGB>
     /// <returns>
     /// <see langword="true" /> if <paramref name="obj" /> is a <see cref="T:MelonLoader.Bootstrap.Logging.ColorARGB" /> structure equivalent to this <see cref="T:MelonLoader.Bootstrap.Logging.ColorARGB" /> structure; otherwise, <see langword="false" />.
     /// </returns>
+#pragma warning disable CS8765 // Nullability of type of parameter doesn't match overridden member (possibly because of nullability attributes).
     public override bool Equals(object obj)
+#pragma warning restore CS8765 // Nullability of type of parameter doesn't match overridden member (possibly because of nullability attributes).
     {
         return obj is ColorARGB color && value == color.value;
     }

--- a/MelonLoader.Bootstrap/Logging/ConsoleHandler.cs
+++ b/MelonLoader.Bootstrap/Logging/ConsoleHandler.cs
@@ -27,9 +27,10 @@ internal static class ConsoleHandler
     public static void OpenConsole(bool onTop, string? title)
     {
 #if WINDOWS
-        // Do not create a new window if a window already exists
+        // Do not create a new window if a window already exists or the output is being redirected
         var consoleWindow = WindowsNative.GetConsoleWindow();
-        if (consoleWindow == 0)
+        var stdOut = WindowsNative.GetStdHandle(WindowsNative.StdOutputHandle);
+        if (consoleWindow == 0 && stdOut == 0)
         {
             WindowsNative.AllocConsole();
             consoleWindow = WindowsNative.GetConsoleWindow();

--- a/MelonLoader.Bootstrap/Logging/ConsoleHandler.cs
+++ b/MelonLoader.Bootstrap/Logging/ConsoleHandler.cs
@@ -1,6 +1,7 @@
 ﻿using MelonLoader.Logging;
 using System.Runtime.InteropServices;
 using System.Text;
+using MelonLoader.Bootstrap.Utils;
 
 namespace MelonLoader.Bootstrap;
 
@@ -31,7 +32,7 @@ internal static class ConsoleHandler
         // On Wine, we always want to show the window because it's possible the handle isn't null due to Wine itself
         var consoleWindow = WindowsNative.GetConsoleWindow();
         var stdOut = WindowsNative.GetStdHandle(WindowsNative.StdOutputHandle);
-        if (consoleWindow == 0 && (stdOut == 0 || IsWine()))
+        if (consoleWindow == 0 && (stdOut == 0 || WineUtils.IsWine))
         {
             WindowsNative.AllocConsole();
             consoleWindow = WindowsNative.GetConsoleWindow();
@@ -76,16 +77,6 @@ internal static class ConsoleHandler
 
         IsOpen = true;
     }
-
-#if WINDOWS
-    private static bool IsWine()
-    {
-        if (!NativeLibrary.TryLoad("ntdll.dll", out var handle))
-            return false;
-        bool isWine = NativeLibrary.TryGetExport(handle, "wine_get_version", out _);
-        return isWine;
-    }
-#endif
 
     public static void NullHandles()
     {

--- a/MelonLoader.Bootstrap/RuntimeHandlers/Il2Cpp/Il2CppHandler.cs
+++ b/MelonLoader.Bootstrap/RuntimeHandlers/Il2Cpp/Il2CppHandler.cs
@@ -11,6 +11,14 @@ internal static class Il2CppHandler
     private static bool il2cppInitDone;
     private static bool invokeStarted;
 
+    private static readonly Il2CppLib.InitFn Il2CPPInitDetourFn = InitDetour;
+    private static readonly Il2CppLib.RuntimeInvokeFn InvokeDetourFn = InvokeDetour;
+    internal static readonly Dictionary<string, (Action<nint> InitMethod, IntPtr detourPtr)> SymbolRedirects = new()
+    {
+        { "il2cpp_init", (Initialize, Marshal.GetFunctionPointerForDelegate(Il2CPPInitDetourFn))},
+        { "il2cpp_runtime_invoke", (Initialize, Marshal.GetFunctionPointerForDelegate(InvokeDetourFn))},
+    };
+
     public static void Initialize(nint handle)
     {
         var il2cppLib = Il2CppLib.TryLoad(handle);

--- a/MelonLoader/Core.cs
+++ b/MelonLoader/Core.cs
@@ -24,70 +24,6 @@ namespace MelonLoader
 
         internal static HarmonyLib.Harmony HarmonyInstance;
         internal static bool Is_ALPHA_PreRelease = false;
-        private static bool MonoCoreStartEntrypointAlreadyCalled = false;
-        private static MethodInfo MonoCoreStartHookMethod;
-
-        // First step of the Mono Core.Start entrypoint: Harmony patch the main Unity assembly with a suitable hook
-        private static void OnAssemblyLoad(object sender, AssemblyLoadEventArgs args)
-        {
-            const string sceneManagerTypeName = "UnityEngine.SceneManagement.SceneManager";
-            const string displayTypeName = "UnityEngine.Display";
-            
-            var assembly = args.LoadedAssembly;
-            var assemblyName = assembly.GetName().Name;
-
-            if (assemblyName is not ("UnityEngine.CoreModule" or "UnityEngine"))
-                return;
-
-            try 
-            { 
-                AppDomain.CurrentDomain.AssemblyLoad -= OnAssemblyLoad;
-
-                var sceneManagerType = assembly.GetType(sceneManagerTypeName, false);
-                if (sceneManagerType != null)
-                {
-                    MonoCoreStartHookMethod = sceneManagerType.GetMethod("Internal_ActiveSceneChanged", BindingFlags.NonPublic | BindingFlags.Static);
-                    HarmonyInstance.Patch(MonoCoreStartHookMethod, prefix: new HarmonyMethod(typeof(Core), nameof(Entrypoint)));
-                    MelonLogger.Msg($"Hooked into {MonoCoreStartHookMethod.FullDescription()}");
-                    return;
-                }
-
-                var displayType = assembly.GetType(displayTypeName, false);
-                if (displayType != null)
-                {
-                    MonoCoreStartHookMethod = displayType.GetMethod("RecreateDisplayList", BindingFlags.NonPublic | BindingFlags.Static);
-                    HarmonyInstance.Patch(MonoCoreStartHookMethod, postfix: new HarmonyMethod(typeof(Core), nameof(Entrypoint)));
-                    MelonLogger.Msg($"Hooked into {MonoCoreStartHookMethod.FullDescription()}");
-                    return;
-                }
-
-                MelonLogger.Error($"Couldn't find a suitable Core.Start entrypoint in the {assemblyName} assembly because " +
-                                  $"{sceneManagerTypeName} or {displayTypeName} do not exist in the assembly");
-            }
-            catch (Exception e)
-            {
-                MelonLogger.Error($"Unexpected error occured when trying to hook into {assemblyName}: {e}");
-            }
-        }
-
-        // Second step of the Mono Core.Start entrypoint: undo the Harmony patch and call the Core.Start method
-        private static void Entrypoint()
-        {
-            if (MonoCoreStartEntrypointAlreadyCalled)
-                return;
-
-            MonoCoreStartEntrypointAlreadyCalled = true;
-            try
-            {
-                HarmonyInstance.Unpatch(MonoCoreStartHookMethod, HarmonyPatchType.All, BuildInfo.Name);
-            }
-            catch (Exception e)
-            {
-                MelonLogger.Error($"Unexpected error when trying to unhook the Core.Start entrypoint: {e}");
-            }
-
-            Start();
-        }
 
         internal static int Initialize()
         {
@@ -229,7 +165,7 @@ namespace MelonLoader
 #if !NET6_0_OR_GREATER
             // Set up the Core.Start entrypoint which harmony patches the main Unity assembly as soon as possible and
             // unpatch it in our hooking method before calling the Core.Start method
-            AppDomain.CurrentDomain.AssemblyLoad += OnAssemblyLoad;
+            MonoCoreEntrypoint.Init();
 #endif
 
             return 0;

--- a/MelonLoader/InternalUtils/MonoCoreEntrypoint.cs
+++ b/MelonLoader/InternalUtils/MonoCoreEntrypoint.cs
@@ -1,0 +1,85 @@
+﻿#if !NET6_0_OR_GREATER
+using System;
+using System.Reflection;
+using HarmonyLib;
+
+namespace MelonLoader.InternalUtils;
+
+public static class MonoCoreEntrypoint
+{
+    private static bool _monoCoreStartEntrypointAlreadyCalled;
+    private static MethodInfo _monoCoreStartHookMethod;
+
+    internal static void Init()
+    {
+        AppDomain.CurrentDomain.AssemblyLoad += OnAssemblyLoad;
+    }
+    
+    // First step of the Mono Core.Start entrypoint: Harmony patch the main Unity assembly with a suitable hook
+    private static void OnAssemblyLoad(object sender, AssemblyLoadEventArgs args)
+    {
+        const string sceneManagerTypeName = "UnityEngine.SceneManagement.SceneManager";
+        const string displayTypeName = "UnityEngine.Display";
+
+        var assembly = args.LoadedAssembly;
+        var assemblyName = assembly.GetName().Name;
+
+        if (assemblyName is not ("UnityEngine.CoreModule" or "UnityEngine"))
+            return;
+
+        try
+        {
+            AppDomain.CurrentDomain.AssemblyLoad -= OnAssemblyLoad;
+
+            var sceneManagerType = assembly.GetType(sceneManagerTypeName, false);
+            if (sceneManagerType != null)
+            {
+                _monoCoreStartHookMethod = sceneManagerType.GetMethod("Internal_ActiveSceneChanged",
+                    BindingFlags.NonPublic | BindingFlags.Static);
+                Core.HarmonyInstance.Patch(_monoCoreStartHookMethod,
+                    prefix: new HarmonyMethod(typeof(MonoCoreEntrypoint), nameof(Entrypoint)));
+                MelonLogger.Msg($"Hooked into {_monoCoreStartHookMethod.FullDescription()}");
+                return;
+            }
+
+            var displayType = assembly.GetType(displayTypeName, false);
+            if (displayType != null)
+            {
+                _monoCoreStartHookMethod =
+                    displayType.GetMethod("RecreateDisplayList", BindingFlags.NonPublic | BindingFlags.Static);
+                Core.HarmonyInstance.Patch(_monoCoreStartHookMethod,
+                    postfix: new HarmonyMethod(typeof(MonoCoreEntrypoint), nameof(Entrypoint)));
+                MelonLogger.Msg($"Hooked into {_monoCoreStartHookMethod.FullDescription()}");
+                return;
+            }
+
+            MelonLogger.Error(
+                $"Couldn't find a suitable Core.Start entrypoint in the {assemblyName} assembly because " +
+                $"{sceneManagerTypeName} or {displayTypeName} do not exist in the assembly");
+        }
+        catch (Exception e)
+        {
+            MelonLogger.Error($"Unexpected error occured when trying to hook into {assemblyName}: {e}");
+        }
+    }
+
+    // Second step of the Mono Core.Start entrypoint: undo the Harmony patch and call the Core.Start method
+    private static void Entrypoint()
+    {
+        if (_monoCoreStartEntrypointAlreadyCalled)
+            return;
+
+        _monoCoreStartEntrypointAlreadyCalled = true;
+        try
+        {
+            Core.HarmonyInstance.Unpatch(_monoCoreStartHookMethod, HarmonyPatchType.All, BuildInfo.Name);
+        }
+        catch (Exception e)
+        {
+            MelonLogger.Error($"Unexpected error when trying to unhook the Core.Start entrypoint: {e}");
+        }
+
+        Core.Start();
+    }
+}
+#endif


### PR DESCRIPTION
@slxdy sent several code reviews and this PR partially addresses them.

Here's all the changes:

#871 Addressed the warning via pragma suppression (proper fix would be enabling nullable, but this is simply not feasible without a complete rewrite of several apis and the deletion of obsoleted ones)
#875 Moved the Mono specific entrypoint to its own class that Core uses
#877 Did nothing for this one because it's not possible to address: the MSBuild changes are required even if one specify the exports file to the linker because .net still mangles them with versions we don't want on Linux
#855 Fixed the bad "--" on the capture player logs CLI arg. As for the PltHook stuff, I didn't do anything because I don't understand the review comment: PltHook is NOT an alternative to dobby because it is more specialised and can't be used for general purpose hooks which is what dobby is for. The way we use PltHook is meant ONLY for the bootstrap so I don't understand why it needs to have a matching api...it doesn't really make sense to me
#887 For the comments on the runtime handlers, I decided to split the dictionnary into 2 where each handlers have their parts and the common RedirectSymbol is the one that consults the 2 from the runtimes. That's essentially the best I can do to leave runtime specific stuff out of core without code duplications. As for the HookGetProcAddress, nothing was done because trying this reveals that NativeLibrary.GetExport is semantically incompatible with dlsym (it doesn't understand that a null handle means "the main library")
#890 Removed the "--" on the harmony log level CLI arg
#900 Simplified the base dir obtention on MacOS...but not in the suggested ways because it doesn't work (doing a combine on .. doesn't do anything). Instead, I made a method that simplifies reading the code, but it does the same semantically
#905 Reverted the commit, but added a check for wine instead as suggested. I tested both on Windows and Linux with Wine/Proton and this check seemed to work. I also verified indeed that reverting was necessary for powershell redirection to work

Note for @HerpDerpinstine : As mentioned in #871 , the ColorRGB breaking change needs to be mentioned somewhere in the next version's release notes.

That should cover most things