### PR TITLE
Prevent capturing stdout / stderr when capture player logs is disabled

### DIFF
--- a/MelonLoader.Bootstrap/Core.cs
+++ b/MelonLoader.Bootstrap/Core.cs
@@ -54,6 +54,8 @@ public static class Core
             return;
 
         MelonLogger.Init();
+        if (!LoaderConfig.Current.Loader.CapturePlayerLogs)
+            ConsoleHandler.NullHandles();
 
 #if LINUX || OSX
         PltHook.InstallHooks
@@ -77,7 +79,12 @@ public static class Core
 
         MelonDebug.Log($"Redirecting {symbolName}");
         if (!_runtimeInitialised)
+        {
             redirect.InitMethod(handle);
+            if (!LoaderConfig.Current.Loader.CapturePlayerLogs)
+                ConsoleHandler.ResetHandles();
+        }
+
         _runtimeInitialised = true;
         return redirect.detourPtr;
     }


### PR DESCRIPTION
This fixes a regression where stdout and stderr where captured to the logs by default when they previously didn't.

This was due to a mistake when implementing the capture player logs setting since it was supposed to manage BOTH player logging AND stdout / stderr logging, but it was only managing the former.

This restores the old behavior by default.

I tested on schedule 1 demo as well as Bug Fables.