### PR TITLE
Check for zero-length strings in ldLibraryPath when making newLibraryPath in RemoveLibraryPreloadEnv

### DIFF
--- a/MelonLoader.Bootstrap/Exports.cs
+++ b/MelonLoader.Bootstrap/Exports.cs
@@ -104,7 +104,7 @@ internal static class Exports
 #endif
 
             string newLibraryPath = string.Join(':', ldLibraryPaths
-                .Where(x => expectedLibFullPath != Path.TrimEndingDirectorySeparator(Path.GetFullPath(x))));
+                .Where(x => x.Length != 0 && expectedLibFullPath != Path.TrimEndingDirectorySeparator(Path.GetFullPath(x))));
             LibcNative.Setenv(LdPathEnvName, newLibraryPath, true);
             Environment.SetEnvironmentVariable(LdPathEnvName, newLibraryPath);
         }


### PR DESCRIPTION
This prevents an ArgumentException from Path.GetFullPath(x) when LD_LIBRARY_PATH has a stray separator character.

This fixes a crash I've experienced when running a Linux native game with the recommended launch options.
Eg: If you run a game with `LD_LIBRARY_PATH="/full/path/to/game/directory:$LD_LIBRARY_PATH" LD_PRELOAD="libversion.so" %command%` and `LD_LIBRARY_PATH` is unset (like it is for me on openSUSE), LD_LIBRARY_PATH will have a stray separator character at the end like `"/foo/bar:"`
`string.Split(':')` will split this as as `["/foo/bar", ""]`, and then this empty string will be passed into `Path.GetFullPath(x)` which throws an ArgumentException when given an empty string.

I have tested this this and works for me.