### PR TITLE
Use #if WINDOWS instead of checking MelonUtils.CurrentPlatform for WindowsUnhandledQuit fix Take 2

### DIFF
--- a/MelonLoader/Core.cs
+++ b/MelonLoader/Core.cs
@@ -149,12 +149,10 @@ namespace MelonLoader
 
             PatchShield.Install();
 
-            if (MelonUtils.CurrentPlatform == MelonPlatformAttribute.CompatiblePlatforms.WINDOWS_X86
-                || MelonUtils.CurrentPlatform == MelonPlatformAttribute.CompatiblePlatforms.WINDOWS_X64)
-            {
-                Fixes.WindowsUnhandledQuit.Install();
-                MelonEvents.OnUpdate.Subscribe(Fixes.WindowsUnhandledQuit.Update, int.MaxValue);
-            }
+#if WINDOWS
+            Fixes.WindowsUnhandledQuit.Install();
+            MelonEvents.OnUpdate.Subscribe(Fixes.WindowsUnhandledQuit.Update, int.MaxValue);
+#endif
 
             MelonPreferences.Load();
 


### PR DESCRIPTION
This is untested on windows, but seems to match how every other platform-dependent fix works. This fixes MelonLoader on Linux for me.

IDK if this had to be a separate PR, but GitHub didn't have any obvious button to change which branch to merge to so this just seemed easier.