### PR TITLE
Allow exclamation marks in namespaces/types

### DIFF
--- a/MelonLoader/Utils/AssemblyVerifier.cs
+++ b/MelonLoader/Utils/AssemblyVerifier.cs
@@ -32,7 +32,8 @@ namespace MelonLoader.Utils
             ')',
             '?',
             '{',
-            '}'
+            '}',
+            '!'
         };
 
         [MethodImpl(MethodImplOptions.NoInlining)]


### PR DESCRIPTION
When using [ILMerge.Fody](https://www.nuget.org/packages/ILMerge.Fody), it can produce type names with exclamation marks in the name, which causes MelonLoader to reject the assembly. I believe it should allow the `!` because it doesn't really cause any more problems than characters like `<`.
<img width="1161" height="203" alt="Auto-generated type with an exclamation mark in the name" src="https://github.com/user-attachments/assets/df2da0fe-89a8-40da-a8a8-b0df066d485c" />
