### PR TITLE
Fix MsgPastel not working as intended

### DIFF
--- a/MelonLoader.Bootstrap/InternalLogger.cs
+++ b/MelonLoader.Bootstrap/InternalLogger.cs
@@ -7,7 +7,7 @@ internal class InternalLogger(ColorARGB sectionColor, string sectionName)
 {
     public void Msg(string msg)
     {
-        MelonLogger.Log(ColorARGB.LightGray, msg, sectionColor, sectionName);
+        MelonLogger.Log(ColorARGB.LightGray, msg, sectionColor, sectionName, msg);
     }
 
     public void Error(string msg)

--- a/MelonLoader.Bootstrap/Logging/MelonLogger.cs
+++ b/MelonLoader.Bootstrap/Logging/MelonLogger.cs
@@ -137,11 +137,11 @@ internal static class MelonLogger
         }
     }
 
-    public static void Log(ColorARGB msgColor, ReadOnlySpan<char> msg)
+    public static void Log(ColorARGB msgColor, ReadOnlySpan<char> msg, ReadOnlySpan<char> strippedMessage)
     {
         var time = DateTime.Now.ToString(timeFormat);
 
-        LogToFiles($"[{time}] {msg}");
+        LogToFiles($"[{time}] {strippedMessage}");
 
         if (!ConsoleHandler.IsOpen)
             return;
@@ -166,11 +166,12 @@ internal static class MelonLogger
         Console.WriteLine($"[{time.Pastel(timeColor)}] {msg.Pastel(msgColor)}");
     }
 
-    public static void Log(ColorARGB msgColor, ReadOnlySpan<char> msg, ColorARGB sectionColor, ReadOnlySpan<char> sectionName)
+    // HACK: There's definitely a better way to implement MsgPastel, but for now this will do. This required the strippedMessage parameter to be provided which isn't really optimal
+    public static void Log(ColorARGB msgColor, ReadOnlySpan<char> msg, ColorARGB sectionColor, ReadOnlySpan<char> sectionName, ReadOnlySpan<char> strippedMessage)
     {
         var time = DateTime.Now.ToString(timeFormat);
 
-        LogToFiles($"[{time}] [{sectionName}] {msg}");
+        LogToFiles($"[{time}] [{sectionName}] {strippedMessage}");
 
         if (!ConsoleHandler.IsOpen)
             return;
@@ -211,7 +212,7 @@ internal static class MelonLogger
             return;
         }
 
-        Log(ColorARGB.Yellow, msg);
+        Log(ColorARGB.Yellow, msg, msg);
     }
 
     public static void LogWarning(ReadOnlySpan<char> msg, ReadOnlySpan<char> sectionName)
@@ -224,7 +225,7 @@ internal static class MelonLogger
             return;
         }
 
-        Log(ColorARGB.Yellow, msg, ColorARGB.Yellow, sectionName);
+        Log(ColorARGB.Yellow, msg, ColorARGB.Yellow, sectionName, msg);
     }
 
     public static void LogError(ReadOnlySpan<char> msg)

--- a/MelonLoader.Bootstrap/SharedDelegates.cs
+++ b/MelonLoader.Bootstrap/SharedDelegates.cs
@@ -1,4 +1,5 @@
 ﻿using MelonLoader.Logging;
+
 using System.Runtime.InteropServices;
 
 namespace MelonLoader.Bootstrap;
@@ -7,7 +8,7 @@ namespace MelonLoader.Bootstrap;
 internal unsafe delegate void NativeHookFn(nint* target, nint detour);
 
 [UnmanagedFunctionPointer(CallingConvention.StdCall, CharSet = CharSet.Unicode)]
-internal unsafe delegate void LogMsgFn(ColorARGB* msgColor, string msg, int msgLength, ColorARGB* sectionColor, string section, int sectionLength);
+internal unsafe delegate void LogMsgFn(ColorARGB* msgColor, string msg, int msgLength, ColorARGB* sectionColor, string section, int sectionLength, string strippedMSg, int strippedMsgLength);
 
 [UnmanagedFunctionPointer(CallingConvention.StdCall, CharSet = CharSet.Unicode)]
 internal unsafe delegate void LogErrorFn(string msg, int msgLength, string section, int sectionLength, bool warning);

--- a/MelonLoader/Utils/MelonLogger.cs
+++ b/MelonLoader/Utils/MelonLogger.cs
@@ -240,7 +240,7 @@ namespace MelonLoader
             // Regex to check for ANSI
             var cleanTxt = Regex.Replace(txt, @"(\x1B|\e|\033)\[(.*?)m", "");
 
-            PassLogMsg(txt_color, cleanTxt, namesection_color, namesection);
+            PassLogMsg(txt_color, txt, namesection_color, namesection, cleanTxt);
         }
 
         internal static void Warning(string namesection, string txt)
@@ -252,7 +252,7 @@ namespace MelonLoader
 
         internal static unsafe void WriteSpacer()
         {
-            BootstrapInterop.Library.LogMsg(null, null, 0, null, null, 0);
+            BootstrapInterop.Library.LogMsg(null, null, 0, null, null, 0, null, 0);
         }
 
         internal static void PrintModName(ColorARGB meloncolor, ColorARGB authorcolor, string name, string author, string additionalCredits, string version, string id)
@@ -264,14 +264,16 @@ namespace MelonLoader
                 PassLogMsg(DefaultTextColor, $"Additional credits: {additionalCredits}", default, null);
         }
 
-        internal static unsafe void PassLogMsg(ColorARGB msgColor, string msg, ColorARGB sectionColor, string section)
+        internal static unsafe void PassLogMsg(ColorARGB msgColor, string msg, ColorARGB sectionColor, string section, string strippedMsg = null)
         {
+            strippedMsg ??= msg;
+
             if (section == null)
             {
-                BootstrapInterop.Library.LogMsg(&msgColor, msg, msg.Length, null, null, 0);
+                BootstrapInterop.Library.LogMsg(&msgColor, msg, msg.Length, null, null, 0, strippedMsg, strippedMsg.Length);
                 return;
             }
-            BootstrapInterop.Library.LogMsg(&msgColor, msg, msg.Length, &sectionColor, section, section.Length);
+            BootstrapInterop.Library.LogMsg(&msgColor, msg, msg.Length, &sectionColor, section, section.Length, strippedMsg, strippedMsg.Length);
         }
 
         internal static void PassLogError(string msg, string section, bool warning)


### PR DESCRIPTION
This fixes how MsgPastel works after the rework of logger in commit [3269d42](https://github.com/LavaGang/MelonLoader/commit/3269d42ab66bf525e5086a0f5671a666d97301dc). Instead of completely removing the ANSI from both console and file, a new parameter to the logging method called "strippedMessage" was added which is written to the file.

This is a pretty hacky way of doing it and there's definitely a better way, but for now that should at least temporarily fix the issue

Resolves #1040 #1034