### PR TITLE
fix MelonLaunchOptions

### DIFF
--- a/MelonLoader/MelonLaunchOptions.cs
+++ b/MelonLoader/MelonLaunchOptions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace MelonLoader
@@ -64,11 +64,11 @@ namespace MelonLoader
 
                 // Parse Argument
                 string cmdArg = null;
-                if (noPrefixCmd.Contains("="))
+                int equalsPos = noPrefixCmd.IndexOf('=');
+                if (equalsPos > -1)
                 {
-                    string[] split = noPrefixCmd.Split('=');
-                    noPrefixCmd = split[0];
-                    cmdArg = split[1];
+                    cmdArg = noPrefixCmd.Substring(equalsPos + 1);
+                    noPrefixCmd = noPrefixCmd.Substring(0, equalsPos);
                 }
 
                 if ((string.IsNullOrEmpty(cmdArg)


### PR DESCRIPTION
i was getting the error of

```
[19:16:46.843] Failed to initialize MelonLoader
Unhandled exception. System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
 ---> System.Exception: System.NullReferenceException: Object reference not set to an instance of an object.
   at System.SpanHelpers.IndexOf(Char& searchSpace, Char value, Int32 length)
   at MelonLoader.Core.Initialize() in C:\Users\Administrator\Downloads\MelonLoader-alpha-development\MelonLoader-alpha-development\MelonLoader\Core.cs:line 32
   at MelonLoader.InternalUtils.BootstrapInterop.Initialize(IntPtr bootstrapHandle) in C:\Users\Administrator\Downloads\MelonLoader-alpha-development\MelonLoader-alpha-development\MelonLoader\InternalUtils\BootstrapInterop.cs:line 91
   at MelonLoader.NativeHost.NativeEntryPoint.CallInit(IntPtr* startFunc) in C:\Users\Administrator\Downloads\MelonLoader-alpha-development\MelonLoader-alpha-development\MelonLoader.NativeHost\NativeEntryPoint.cs:line 44
   at MelonLoader.NativeHost.NativeEntryPoint.Initialize(IntPtr* startFunc) in C:\Users\Administrator\Downloads\MelonLoader-alpha-development\MelonLoader-alpha-development\MelonLoader.NativeHost\NativeEntryPoint.cs:line 31
   --- End of inner exception stack trace ---
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Span`1& arguments, Signature sig, Boolean constructor, Boolean wrapExceptions)
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at MelonLoader.NativeHost.NativeEntryPoint.NativeEntry(IntPtr* startFunc) in C:\Users\Administrator\Downloads\MelonLoader-alpha-development\MelonLoader-alpha-development\MelonLoader.NativeHost\NativeEntryPoint.cs:line 18
```

but after i did that it fixed