### PR TITLE
Add support for portable .NET runtime in game root

### DIFF
--- a/MelonLoader.Bootstrap/RuntimeHandlers/Il2Cpp/Il2CppHandler.cs
+++ b/MelonLoader.Bootstrap/RuntimeHandlers/Il2Cpp/Il2CppHandler.cs
@@ -1,4 +1,8 @@
 ﻿using MelonLoader.Bootstrap.Utils;
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 
 namespace MelonLoader.Bootstrap.RuntimeHandlers.Il2Cpp;
@@ -65,7 +69,17 @@ internal static class Il2CppHandler
             return;
         }
 
-        MelonDebug.Log("Attempting to load hostfxr");
+        // 1) First try to use a portable .NET runtime in the game root
+        MelonDebug.Log("Checking for portable .NET runtime in game root");
+        if (TryConfigurePortableDotnet())
+        {
+            MelonDebug.Log("Attempting to load hostfxr using portable .NET runtime");
+            if (Dotnet.LoadHostfxr())
+                goto HostfxrLoaded;
+        }
+
+        // 2) If no portable runtime is found or it fails, use the normal system detection/installation
+        MelonDebug.Log("Attempting to load hostfxr from system");
         if (!Dotnet.LoadHostfxr())
         {
             DotnetInstaller.AttemptInstall();
@@ -75,6 +89,8 @@ internal static class Il2CppHandler
                 return;
             }
         }
+
+    HostfxrLoaded:
 
         MelonDebug.Log("Initializing domain");
         if (!Dotnet.InitializeForRuntimeConfig(runtimeConfigPath, out var context))
@@ -107,6 +123,55 @@ internal static class Il2CppHandler
         }
 
         startFunc = Marshal.GetDelegateForFunctionPointer<Action>(startFuncPtr);
+    }
+
+    private static bool TryConfigurePortableDotnet()
+    {
+#if WINDOWS
+        try
+        {
+            var process = Process.GetCurrentProcess();
+            var exePath = process?.MainModule?.FileName;
+            if (string.IsNullOrEmpty(exePath))
+                return false;
+
+            var gameRoot = Path.GetDirectoryName(exePath);
+            if (string.IsNullOrEmpty(gameRoot) || !Directory.Exists(gameRoot))
+                return false;
+
+            var candidateDirs = Directory.GetDirectories(gameRoot, "*", SearchOption.TopDirectoryOnly);
+            var portableDir = candidateDirs
+                .FirstOrDefault(d =>
+                {
+                    var name = Path.GetFileName(d);
+                    return name != null && name.IndexOf("dotnet", StringComparison.OrdinalIgnoreCase) >= 0;
+                });
+
+            if (portableDir == null)
+                return false;
+
+            var hostfxrPath = Directory.GetFiles(portableDir, "hostfxr.dll", SearchOption.AllDirectories).FirstOrDefault();
+            if (hostfxrPath == null)
+                return false;
+
+            Environment.SetEnvironmentVariable("DOTNET_ROOT", portableDir);
+
+            var path = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+            var pathEntries = path.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries);
+            if (!pathEntries.Any(p => string.Equals(p, portableDir, StringComparison.OrdinalIgnoreCase)))
+                Environment.SetEnvironmentVariable("PATH", portableDir + Path.PathSeparator + path);
+
+            Core.Logger.Msg($"Using portable .NET runtime from game root: '{portableDir}'");
+
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+#else
+        return false;
+#endif
     }
 
     internal static nint InvokeDetour(nint method, nint obj, nint args, nint exc)


### PR DESCRIPTION
## Summary

This PR adds support for using a **portable .NET runtime** located in the game root directory before falling back to the system-installed runtime and the existing .NET installer logic.

The goal is to allow MelonLoader to run on machines without administrator privileges by shipping a self-contained .NET runtime next to the game.

---

## Changes

- **Il2CppHandler.InitializeManaged**
  - Keeps the existing logic that:
    - Resolves `MelonLoader.runtimeconfig.json` and `MelonLoader.NativeHost.dll` under `MelonLoader/net6`.
    - Loads `hostfxr` and initializes the .NET runtime via [Dotnet](cci:2://file:///c:/Users/Josemi/Desktop/MelonLoaderNoPrivileges/MelonLoader.Bootstrap/RuntimeHandlers/Il2Cpp/Dotnet.cs:5:0-90:1) and [DotnetInstaller](cci:2://file:///c:/Users/Josemi/Desktop/MelonLoaderNoPrivileges/MelonLoader.Bootstrap/RuntimeHandlers/Il2Cpp/DotnetInstaller.cs:4:0-72:1).
  - Adds a new step **before** the system detection:
    1. Logs: `Checking for portable .NET runtime in game root`.
    2. Calls a new helper [TryConfigurePortableDotnet()](cci:1://file:///c:/Users/Josemi/Desktop/MelonLoaderNoPrivileges/MelonLoader.Bootstrap/RuntimeHandlers/Il2Cpp/Il2CppHandler.cs:124:4-171:5):
       - Searches the game root (directory of the game executable) for any **top-level folder whose name contains `dotnet`** (case-insensitive), e.g. `dotnet`, `dotnet-x64`, `DotNet-6.0`, etc.
       - Verifies that this folder contains a `hostfxr.dll` somewhere inside (any subdirectory).
       - If valid:
         - Sets `DOTNET_ROOT` to that folder.
         - Prepends the folder to `PATH` if it is not already present.
         - Logs: `Using portable .NET runtime from game root: '<folder>'`.
    3. If the helper succeeded, attempts to load hostfxr again:
       - Logs: `Attempting to load hostfxr using portable .NET runtime`.
       - If [Dotnet.LoadHostfxr()](cci:1://file:///c:/Users/Josemi/Desktop/MelonLoaderNoPrivileges/MelonLoader.Bootstrap/RuntimeHandlers/Il2Cpp/Dotnet.cs:20:4-24:5) now succeeds, it proceeds with the existing `HostfxrLoaded` flow.
  - If no portable runtime is found or loading it fails:
    - Logs: `Attempting to load hostfxr from system`.
    - Falls back to the existing behavior:
      - Try [Dotnet.LoadHostfxr()](cci:1://file:///c:/Users/Josemi/Desktop/MelonLoaderNoPrivileges/MelonLoader.Bootstrap/RuntimeHandlers/Il2Cpp/Dotnet.cs:20:4-24:5) using the system-installed .NET runtime.
      - If that fails, run [DotnetInstaller.AttemptInstall()](cci:1://file:///c:/Users/Josemi/Desktop/MelonLoaderNoPrivileges/MelonLoader.Bootstrap/RuntimeHandlers/Il2Cpp/DotnetInstaller.cs:13:4-18:5) and try again.
      - On repeated failure, logs `Failed to load Hostfxr` and aborts as before.

- **New helper: [TryConfigurePortableDotnet](cci:1://file:///c:/Users/Josemi/Desktop/MelonLoaderNoPrivileges/MelonLoader.Bootstrap/RuntimeHandlers/Il2Cpp/Il2CppHandler.cs:124:4-171:5) (Windows only)**
  - Uses `Process.GetCurrentProcess().MainModule?.FileName` to determine the game executable path and its directory (game root).
  - Enumerates top-level directories in the game root and finds the first whose name contains `dotnet` (case-insensitive).
  - Checks that at least one `hostfxr.dll` exists under that directory (any depth).
  - On success:
    - Sets `DOTNET_ROOT` to the portable runtime directory.
    - Ensures the directory is present in `PATH` (prepends it if missing).
    - Logs the selected directory with `Core.Logger.Msg`.
    - Returns `true`.
  - On any failure (no directory, no `hostfxr.dll`, IO errors, etc.) returns `false` without changing the existing behavior.
  - Wrapped in `#if WINDOWS` so it is a no-op on other platforms.

---

## Behavior

- **If a valid portable runtime is present** in the game root:
  - MelonLoader uses that runtime first.
  - No attempt is made to download or run the global .NET runtime installer as long as `hostfxr` can be loaded from the portable runtime.

- **If there is no portable runtime or it is invalid**:
  - The behavior is unchanged:
    - Try to load `hostfxr` from the system-installed .NET runtime.
    - If that fails, download and execute the .NET 6 runtime installer as before.

This keeps existing setups working exactly as they do today while enabling a new workflow where users can bundle a portable .NET runtime with their game (helpful on machines without admin rights).

---

## Rationale

Some environments (e.g. locked-down machines, cybercafés, company PCs) do not allow installing system-wide runtimes. However, it is still possible to place a self-contained .NET runtime next to the game. By teaching MelonLoader to look for a `dotnet*` folder in the game root and use it via `DOTNET_ROOT`, users can run MelonLoader without requiring administrative privileges, while still preserving the default behavior for all other users.

---