### PR TITLE
fixed Wine console not resetting the colors after message output

### DIFF
--- a/MelonLoader.Bootstrap/Logging/MelonLogger.cs
+++ b/MelonLoader.Bootstrap/Logging/MelonLogger.cs
@@ -159,6 +159,7 @@ internal static class MelonLogger
 
             Console.ForegroundColor = ConsoleHandler.GetClosestConsoleColor(msgColor);
             Console.Out.WriteLine(msg);
+            Console.ResetColor();
 
             return;
         }
@@ -201,6 +202,7 @@ internal static class MelonLogger
 
             Console.ForegroundColor = ConsoleHandler.GetClosestConsoleColor(msgColor);
             Console.Out.WriteLine(msg);
+            Console.ResetColor();
 
             return;
         }
@@ -253,6 +255,7 @@ internal static class MelonLogger
         {
             Console.ForegroundColor = ConsoleColor.Red;
             Console.WriteLine($"[{time}] {msg}");
+            Console.ResetColor();
 
             return;
         }
@@ -277,6 +280,8 @@ internal static class MelonLogger
                 Console.WriteLine($"[{time}] [{sectionName}] {msg}");
             else
                 Console.WriteLine($"[{time}] {msg}");
+
+            Console.ResetColor();
 
             return;
         }
@@ -313,6 +318,7 @@ internal static class MelonLogger
 
             Console.ResetColor();
             Console.Out.WriteLine(info);
+            Console.ResetColor();
 
             return;
         }


### PR DESCRIPTION
This is a small fix for the Wine console, which uses its own text coloring code.

The console colors are currently reset only when a new message is written by MelonLogger. This works just fine when it's the only thing writing to the console.

As there are other message sources, their interaction is a bit broken -- non-MelonLogger messages retain the last used text color:

<img width="700" height="56" alt="melon_before_crop" src="https://github.com/user-attachments/assets/58ebb2b2-d268-495d-857e-5faa9bd6b773" />

_vanilla 0.7.1 Open-Beta_

If the mod were to output an error instead of a warning in `OnInitializeMelon()`, the text that follows it would be red, as it has no styling of its own, and is usually shown as default white-on-black text.

I've added `Console.ResetColor()` calls to the end of every Wine-specific output code section (as denoted by `if (WineUtils.IsWine)`) in Bootstrap's MelonLogger file to fix this:

<img width="700" height="56" alt="melon_after_crop" src="https://github.com/user-attachments/assets/30ee4ae7-ab70-44af-80d0-5fc94523eb30" />

_patched 0.7.2 from `alpha-development` branch_
