### PR TITLE
Bump Cpp2IL version to 2022.1.0-pre-release.21

### DIFF
--- a/Dependencies/Il2CppAssemblyGenerator/Packages/Cpp2IL.cs
+++ b/Dependencies/Il2CppAssemblyGenerator/Packages/Cpp2IL.cs
@@ -22,7 +22,7 @@ namespace MelonLoader.Il2CppAssemblyGenerator.Packages
                 Version = RemoteAPI.Info.ForceDumperVersion;
 #endif
             if (string.IsNullOrEmpty(Version) || Version.Equals("0.0.0.0"))
-                Version = $"2022.1.0-pre-release.20";
+                Version = $"2022.1.0-pre-release.21";
             VersionSem = SemVersion.Parse(Version);
 
             Name = nameof(Cpp2IL);


### PR DESCRIPTION
Bumps the default Cpp2IL version from 2022.1.0-pre-release.20 to 2022.1.0-pre-release.21 in `Dependencies/Il2CppAssemblyGenerator/Packages/Cpp2IL.cs`.

Closes:
#1100