### PR TITLE
Fixed Asset Bundles not working in Unity 6.

### DIFF
--- a/UnityUtilities/UnityEngine.Il2CppAssetBundleManager/Il2CppAssetBundle.cs
+++ b/UnityUtilities/UnityEngine.Il2CppAssetBundleManager/Il2CppAssetBundle.cs
@@ -1,28 +1,62 @@
 ﻿using Il2CppInterop.Runtime;
+using Il2CppInterop.Runtime.InteropTypes;
 using Il2CppInterop.Runtime.InteropTypes.Arrays;
+using Il2CppInterop.Runtime.Runtime;
 using MelonLoader;
+using MelonLoader.InternalUtils;
 using System;
+using System.Runtime.InteropServices;
+using System.Xml.Linq;
 
 namespace UnityEngine;
 
 public class Il2CppAssetBundle
 {
+    // Since here we're not using il2cpp_runtime_invoke, but we're resolving the icalls directly, we need to unwrap the object by ourselves.
+    private readonly IntPtr wrappedBundlePtr = IntPtr.Zero;
     private readonly IntPtr bundleptr = IntPtr.Zero;
 
-    public Il2CppAssetBundle(IntPtr ptr) { bundleptr = ptr; }
+    public Il2CppAssetBundle(IntPtr ptr)
+    {
+        if (UnityInformationHandler.EngineVersion.Major >= 6000)
+        {
+            wrappedBundlePtr = ptr;
+            bundleptr = Marshal.ReadIntPtr(wrappedBundlePtr + 0x10); // Skip the Il2CppObject header + read the REAL object ptr from there.
+        }
+        else
+        {
+            bundleptr = ptr;
+        }
+    }
 
     static Il2CppAssetBundle()
     {
-        get_isStreamedSceneAssetBundleDelegateField = IL2CPP.ResolveICall<get_isStreamedSceneAssetBundleDelegate>("UnityEngine.AssetBundle::get_isStreamedSceneAssetBundle");
-        returnMainAssetDelegateField = IL2CPP.ResolveICall<returnMainAssetDelegate>("UnityEngine.AssetBundle::returnMainAsset");
-        ContainsDelegateField = IL2CPP.ResolveICall<ContainsDelegate>("UnityEngine.AssetBundle::Contains");
-        GetAllAssetNamesDelegateField = IL2CPP.ResolveICall<GetAllAssetNamesDelegate>("UnityEngine.AssetBundle::GetAllAssetNames");
-        GetAllScenePathsDelegateField = IL2CPP.ResolveICall<GetAllScenePathsDelegate>("UnityEngine.AssetBundle::GetAllScenePaths");
-        LoadAsset_InternalDelegateField = IL2CPP.ResolveICall<LoadAsset_InternalDelegate>("UnityEngine.AssetBundle::LoadAsset_Internal(System.String,System.Type)");
-        LoadAssetAsync_InternalDelegateField = IL2CPP.ResolveICall<LoadAssetAsync_InternalDelegate>("UnityEngine.AssetBundle::LoadAssetAsync_Internal");
-        LoadAssetWithSubAssets_InternalDelegateField = IL2CPP.ResolveICall<LoadAssetWithSubAssets_InternalDelegate>("UnityEngine.AssetBundle::LoadAssetWithSubAssets_Internal");
-        LoadAssetWithSubAssetsAsync_InternalDelegateField = IL2CPP.ResolveICall<LoadAssetWithSubAssetsAsync_InternalDelegate>("UnityEngine.AssetBundle::LoadAssetWithSubAssetsAsync_Internal");
-        UnloadDelegateField = IL2CPP.ResolveICall<UnloadDelegate>("UnityEngine.AssetBundle::Unload");
+        if (UnityInformationHandler.EngineVersion.Major >= 6000)
+        {
+            get_isStreamedSceneAssetBundleDelegateField = IL2CPP.ResolveICall<get_isStreamedSceneAssetBundleDelegate>("UnityEngine.AssetBundle::get_isStreamedSceneAssetBundle_Injected");
+            returnMainAssetDelegateField = IL2CPP.ResolveICall<returnMainAssetDelegate>("UnityEngine.AssetBundle::returnMainAsset_Injected");
+            ContainsDelegateField_Unity6 = IL2CPP.ResolveICall<ContainsDelegate_Unity6>("UnityEngine.AssetBundle::Contains_Injected");
+            GetAllAssetNamesDelegateField = IL2CPP.ResolveICall<GetAllAssetNamesDelegate>("UnityEngine.AssetBundle::GetAllAssetNames_Injected");
+            GetAllScenePathsDelegateField = IL2CPP.ResolveICall<GetAllScenePathsDelegate>("UnityEngine.AssetBundle::GetAllScenePaths_Injected");
+            LoadAsset_InternalDelegateField_Unity6 = IL2CPP.ResolveICall<LoadAsset_InternalDelegate_Unity6>("UnityEngine.AssetBundle::LoadAsset_Internal_Injected(System.String,System.Type)");
+            LoadAssetAsync_InternalDelegateField_Unity6 = IL2CPP.ResolveICall<LoadAssetAsync_InternalDelegate_Unity6>("UnityEngine.AssetBundle::LoadAssetAsync_Internal_Injected");
+            LoadAssetWithSubAssets_InternalDelegateField_Unity6 = IL2CPP.ResolveICall<LoadAssetWithSubAssets_InternalDelegate_Unity6>("UnityEngine.AssetBundle::LoadAssetWithSubAssets_Internal_Injected");
+            LoadAssetWithSubAssetsAsync_InternalDelegateField_Unity6 = IL2CPP.ResolveICall<LoadAssetWithSubAssetsAsync_InternalDelegate_Unity6>("UnityEngine.AssetBundle::LoadAssetWithSubAssetsAsync_Internal_Injected");
+            UnloadDelegateField = IL2CPP.ResolveICall<UnloadDelegate>("UnityEngine.AssetBundle::Unload_Injected");
+        }
+        else
+        {
+            get_isStreamedSceneAssetBundleDelegateField = IL2CPP.ResolveICall<get_isStreamedSceneAssetBundleDelegate>("UnityEngine.AssetBundle::get_isStreamedSceneAssetBundle");
+            returnMainAssetDelegateField = IL2CPP.ResolveICall<returnMainAssetDelegate>("UnityEngine.AssetBundle::returnMainAsset");
+            ContainsDelegateField = IL2CPP.ResolveICall<ContainsDelegate>("UnityEngine.AssetBundle::Contains");
+            GetAllAssetNamesDelegateField = IL2CPP.ResolveICall<GetAllAssetNamesDelegate>("UnityEngine.AssetBundle::GetAllAssetNames");
+            GetAllScenePathsDelegateField = IL2CPP.ResolveICall<GetAllScenePathsDelegate>("UnityEngine.AssetBundle::GetAllScenePaths");
+            LoadAsset_InternalDelegateField = IL2CPP.ResolveICall<LoadAsset_InternalDelegate>("UnityEngine.AssetBundle::LoadAsset_Internal(System.String,System.Type)");
+            LoadAssetAsync_InternalDelegateField = IL2CPP.ResolveICall<LoadAssetAsync_InternalDelegate>("UnityEngine.AssetBundle::LoadAssetAsync_Internal");
+            LoadAssetWithSubAssets_InternalDelegateField = IL2CPP.ResolveICall<LoadAssetWithSubAssets_InternalDelegate>("UnityEngine.AssetBundle::LoadAssetWithSubAssets_Internal");
+            LoadAssetWithSubAssetsAsync_InternalDelegateField = IL2CPP.ResolveICall<LoadAssetWithSubAssetsAsync_InternalDelegate>("UnityEngine.AssetBundle::LoadAssetWithSubAssetsAsync_Internal");
+            UnloadDelegateField = IL2CPP.ResolveICall<UnloadDelegate>("UnityEngine.AssetBundle::Unload");
+        }
     }
 
     public bool isStreamedSceneAssetBundle
@@ -45,8 +79,17 @@ public class Il2CppAssetBundle
                 throw new NullReferenceException("The bundleptr cannot be IntPtr.Zero");
             if (returnMainAssetDelegateField == null)
                 throw new NullReferenceException("The returnMainAssetDelegateField cannot be null.");
-            var intPtr = returnMainAssetDelegateField(bundleptr);
-            return ((intPtr != IntPtr.Zero) ? new Object(intPtr) : null);
+            if (UnityInformationHandler.EngineVersion.Major >= 6000)
+            {
+                // Signature doesn't change, but the resulting ptr is actually a gchandle in Unity 6.
+                var gcHandle = returnMainAssetDelegateField(bundleptr);
+                return ((gcHandle != IntPtr.Zero) ? new Object(Marshal.ReadIntPtr(gcHandle)) : null);
+            }
+            else
+            {
+                var intPtr = returnMainAssetDelegateField(bundleptr);
+                return ((intPtr != IntPtr.Zero) ? new Object(intPtr) : null);
+            }
         }
     }
 
@@ -56,9 +99,29 @@ public class Il2CppAssetBundle
             throw new NullReferenceException("The bundleptr cannot be IntPtr.Zero");
         if (string.IsNullOrEmpty(name))
             throw new ArgumentException("The input asset name cannot be null or empty.");
-        if (ContainsDelegateField == null)
-            throw new NullReferenceException("The ContainsDelegateField cannot be null.");
-        return ContainsDelegateField(bundleptr, IL2CPP.ManagedStringToIl2Cpp(name));
+        if (UnityInformationHandler.EngineVersion.Major >= 6000)
+        {
+            if (ContainsDelegateField_Unity6 == null)
+                throw new NullReferenceException("The ContainsDelegateField_Unity6 cannot be null.");
+            unsafe
+            {
+                fixed (char* charPtr = name)
+                {
+                    var span = new ManagedSpanWrapper
+                    {
+                        begin = charPtr,
+                        length = name.Length
+                    };
+                    return ContainsDelegateField_Unity6(bundleptr, ref span);
+                }
+            }
+        }
+        else
+        {
+            if (ContainsDelegateField == null)
+                throw new NullReferenceException("The ContainsDelegateField cannot be null.");
+            return ContainsDelegateField(bundleptr, IL2CPP.ManagedStringToIl2Cpp(name));
+        }
     }
 
     public Il2CppStringArray AllAssetNames() => GetAllAssetNames();
@@ -119,9 +182,30 @@ public class Il2CppAssetBundle
             throw new ArgumentException("The input asset name cannot be null or empty.");
         if (typeptr == IntPtr.Zero)
             throw new NullReferenceException("The input type cannot be IntPtr.Zero");
-        if (LoadAsset_InternalDelegateField == null)
-            throw new NullReferenceException("The LoadAsset_InternalDelegateField cannot be null.");
-        return LoadAsset_InternalDelegateField(bundleptr, IL2CPP.ManagedStringToIl2Cpp(name), typeptr);
+        if (UnityInformationHandler.EngineVersion.Major >= 6000)
+        {
+            if (LoadAsset_InternalDelegateField_Unity6 == null)
+                throw new NullReferenceException("The LoadAsset_InternalDelegateField_Unity6 cannot be null.");
+            unsafe
+            {
+                fixed (char* charPtr = name)
+                {
+                    var span = new ManagedSpanWrapper
+                    {
+                        begin = charPtr,
+                        length = name.Length
+                    };
+                    var gcHandle = LoadAsset_InternalDelegateField_Unity6(bundleptr, ref span, typeptr);
+                    return ((gcHandle != IntPtr.Zero) ? Marshal.ReadIntPtr(gcHandle) : IntPtr.Zero);
+                }
+            }
+        }
+        else
+        {
+            if (LoadAsset_InternalDelegateField == null)
+                throw new NullReferenceException("The LoadAsset_InternalDelegateField cannot be null.");
+            return LoadAsset_InternalDelegateField(bundleptr, IL2CPP.ManagedStringToIl2Cpp(name), typeptr);
+        }
     }
 
     public Il2CppAssetBundleRequest LoadAssetAsync(string name) => LoadAssetAsync<Object>(name);
@@ -150,9 +234,29 @@ public class Il2CppAssetBundle
             throw new ArgumentException("The input asset name cannot be null or empty.");
         if (typeptr == IntPtr.Zero)
             throw new NullReferenceException("The input type cannot be IntPtr.Zero");
-        if (LoadAssetAsync_InternalDelegateField == null)
-            throw new NullReferenceException("The LoadAssetAsync_InternalDelegateField cannot be null.");
-        return LoadAssetAsync_InternalDelegateField(bundleptr, IL2CPP.ManagedStringToIl2Cpp(name), typeptr);
+        if (UnityInformationHandler.EngineVersion.Major >= 6000)
+        {
+            if (LoadAssetAsync_InternalDelegateField_Unity6 == null)
+                throw new NullReferenceException("The LoadAssetAsync_InternalDelegateField_Unity6 cannot be null.");
+            unsafe
+            {
+                fixed (char* charPtr = name)
+                {
+                    var span = new ManagedSpanWrapper
+                    {
+                        begin = charPtr,
+                        length = name.Length
+                    };
+                    return LoadAssetAsync_InternalDelegateField_Unity6(bundleptr, ref span, typeptr);
+                }
+            }
+        }
+        else
+        {
+            if (LoadAssetAsync_InternalDelegateField == null)
+                throw new NullReferenceException("The LoadAssetAsync_InternalDelegateField cannot be null.");
+            return LoadAssetAsync_InternalDelegateField(bundleptr, IL2CPP.ManagedStringToIl2Cpp(name), typeptr);
+        }
     }
 
     public Il2CppReferenceArray<Object> LoadAll() => LoadAllAssets();
@@ -185,9 +289,29 @@ public class Il2CppAssetBundle
     {
         if (typeptr == IntPtr.Zero)
             throw new NullReferenceException("The input type cannot be IntPtr.Zero");
-        if (LoadAssetWithSubAssets_InternalDelegateField == null)
-            throw new NullReferenceException("The LoadAssetWithSubAssets_InternalDelegateField cannot be null.");
-        return LoadAssetWithSubAssets_InternalDelegateField(bundleptr, IL2CPP.ManagedStringToIl2Cpp(string.Empty), typeptr);
+        if (UnityInformationHandler.EngineVersion.Major >= 6000)
+        {
+            if (LoadAssetWithSubAssets_InternalDelegateField_Unity6 == null)
+                throw new NullReferenceException("The LoadAssetWithSubAssets_InternalDelegateField_Unity6 cannot be null.");
+            unsafe
+            {
+                fixed (char* charPtr = string.Empty)
+                {
+                    var span = new ManagedSpanWrapper
+                    {
+                        begin = charPtr,
+                        length = 0
+                    };
+                    return LoadAssetWithSubAssets_InternalDelegateField_Unity6(bundleptr, ref span, typeptr);
+                }
+            }
+        }
+        else
+        {
+            if (LoadAssetWithSubAssets_InternalDelegateField == null)
+                throw new NullReferenceException("The LoadAssetWithSubAssets_InternalDelegateField cannot be null.");
+            return LoadAssetWithSubAssets_InternalDelegateField(bundleptr, IL2CPP.ManagedStringToIl2Cpp(string.Empty), typeptr);
+        }
     }
 
     public Il2CppReferenceArray<Object> LoadAssetWithSubAssets(string name) => LoadAssetWithSubAssets<Object>(name);
@@ -216,9 +340,29 @@ public class Il2CppAssetBundle
             throw new ArgumentException("The input asset name cannot be null or empty.");
         if (typeptr == IntPtr.Zero)
             throw new NullReferenceException("The input type cannot be IntPtr.Zero");
-        if (LoadAssetWithSubAssets_InternalDelegateField == null)
-            throw new NullReferenceException("The LoadAssetWithSubAssets_InternalDelegateField cannot be null.");
-        return LoadAssetWithSubAssets_InternalDelegateField(bundleptr, IL2CPP.ManagedStringToIl2Cpp(name), typeptr);
+        if (UnityInformationHandler.EngineVersion.Major >= 6000)
+        {
+            if (LoadAssetWithSubAssets_InternalDelegateField_Unity6 == null)
+                throw new NullReferenceException("The LoadAssetWithSubAssets_InternalDelegateField_Unity6 cannot be null.");
+            unsafe
+            {
+                fixed (char* charPtr = name)
+                {
+                    var span = new ManagedSpanWrapper
+                    {
+                        begin = charPtr,
+                        length = name.Length
+                    };
+                    return LoadAssetWithSubAssets_InternalDelegateField_Unity6(bundleptr, ref span, typeptr);
+                }
+            }
+        }
+        else
+        {
+            if (LoadAssetWithSubAssets_InternalDelegateField == null)
+                throw new NullReferenceException("The LoadAssetWithSubAssets_InternalDelegateField cannot be null.");
+            return LoadAssetWithSubAssets_InternalDelegateField(bundleptr, IL2CPP.ManagedStringToIl2Cpp(name), typeptr);
+        }
     }
     public Il2CppAssetBundleRequest LoadAssetWithSubAssetsAsync(string name) => LoadAssetWithSubAssetsAsync<Object>(name);
 
@@ -246,9 +390,29 @@ public class Il2CppAssetBundle
             throw new ArgumentException("The input asset name cannot be null or empty.");
         if (typeptr == IntPtr.Zero)
             throw new NullReferenceException("The input type cannot be IntPtr.Zero");
-        if (LoadAssetWithSubAssetsAsync_InternalDelegateField == null)
-            throw new NullReferenceException("The LoadAssetWithSubAssetsAsync_InternalDelegateField cannot be null.");
-        return LoadAssetWithSubAssetsAsync_InternalDelegateField(bundleptr, IL2CPP.ManagedStringToIl2Cpp(name), typeptr);
+        if (UnityInformationHandler.EngineVersion.Major >= 6000)
+        {
+            if (LoadAssetWithSubAssetsAsync_InternalDelegateField_Unity6 == null)
+                throw new NullReferenceException("The LoadAssetWithSubAssetsAsync_InternalDelegateField_Unity6 cannot be null.");
+            unsafe
+            {
+                fixed (char* charPtr = name)
+                {
+                    var span = new ManagedSpanWrapper
+                    {
+                        begin = charPtr,
+                        length = name.Length
+                    };
+                    return LoadAssetWithSubAssetsAsync_InternalDelegateField_Unity6(bundleptr, ref span, typeptr);
+                }
+            }
+        }
+        else
+        {
+            if (LoadAssetWithSubAssetsAsync_InternalDelegateField == null)
+                throw new NullReferenceException("The LoadAssetWithSubAssetsAsync_InternalDelegateField cannot be null.");
+            return LoadAssetWithSubAssetsAsync_InternalDelegateField(bundleptr, IL2CPP.ManagedStringToIl2Cpp(name), typeptr);
+        }
     }
 
     public void Unload(bool unloadAllLoadedObjects)
@@ -259,11 +423,10 @@ public class Il2CppAssetBundle
             throw new NullReferenceException("The UnloadDelegateField cannot be null.");
         UnloadDelegateField(bundleptr, unloadAllLoadedObjects);
     }
-
     private delegate bool get_isStreamedSceneAssetBundleDelegate(IntPtr _this);
-    private static readonly returnMainAssetDelegate returnMainAssetDelegateField;
-    private delegate IntPtr returnMainAssetDelegate(IntPtr _this);
     private static readonly get_isStreamedSceneAssetBundleDelegate get_isStreamedSceneAssetBundleDelegateField;
+    private delegate IntPtr returnMainAssetDelegate(IntPtr _this);
+    private static readonly returnMainAssetDelegate returnMainAssetDelegateField;
     private delegate bool ContainsDelegate(IntPtr _this, IntPtr name);
     private static readonly ContainsDelegate ContainsDelegateField;
     private delegate IntPtr GetAllAssetNamesDelegate(IntPtr _this);
@@ -280,4 +443,20 @@ public class Il2CppAssetBundle
     private static readonly LoadAssetWithSubAssetsAsync_InternalDelegate LoadAssetWithSubAssetsAsync_InternalDelegateField;
     private delegate void UnloadDelegate(IntPtr _this, bool unloadAllObjects);
     private static readonly UnloadDelegate UnloadDelegateField;
+
+    // get_isStreamedSceneAssetBundle doesn't change.
+    // returnMainAsset doesn't change.
+    private delegate bool ContainsDelegate_Unity6(IntPtr _this, ref ManagedSpanWrapper name);
+    private static readonly ContainsDelegate_Unity6 ContainsDelegateField_Unity6;
+    // GetAllAssetNames doesn't change.
+    // GetAllScenePaths doesn't change.
+    private delegate IntPtr LoadAsset_InternalDelegate_Unity6(IntPtr _this, ref ManagedSpanWrapper name, IntPtr type);
+    private static readonly LoadAsset_InternalDelegate_Unity6 LoadAsset_InternalDelegateField_Unity6;
+    private delegate IntPtr LoadAssetAsync_InternalDelegate_Unity6(IntPtr _this, ref ManagedSpanWrapper name, IntPtr type);
+    private static readonly LoadAssetAsync_InternalDelegate_Unity6 LoadAssetAsync_InternalDelegateField_Unity6;
+    private delegate IntPtr LoadAssetWithSubAssets_InternalDelegate_Unity6(IntPtr _this, ref ManagedSpanWrapper name, IntPtr type);
+    private static readonly LoadAssetWithSubAssets_InternalDelegate_Unity6 LoadAssetWithSubAssets_InternalDelegateField_Unity6;
+    private delegate IntPtr LoadAssetWithSubAssetsAsync_InternalDelegate_Unity6(IntPtr _this, ref ManagedSpanWrapper name, IntPtr type);
+    private static readonly LoadAssetWithSubAssetsAsync_InternalDelegate_Unity6 LoadAssetWithSubAssetsAsync_InternalDelegateField_Unity6;
+    // Unload doesn't change.
 }

--- a/UnityUtilities/UnityEngine.Il2CppAssetBundleManager/Il2CppAssetBundleManager.cs
+++ b/UnityUtilities/UnityEngine.Il2CppAssetBundleManager/Il2CppAssetBundleManager.cs
@@ -1,21 +1,48 @@
 ﻿using Il2CppInterop.Runtime;
 using Il2CppInterop.Runtime.InteropTypes.Arrays;
 using Il2CppSystem.IO;
+using MelonLoader.InternalUtils;
+using System;
+using System.Runtime.InteropServices;
 
 namespace UnityEngine;
+
+// New struct needed for Unity 6 function calls.
+[StructLayout(LayoutKind.Sequential)]
+public struct ManagedSpanWrapper
+{
+    public unsafe void* begin;
+    public int length;
+}
 
 public class Il2CppAssetBundleManager
 {
     static Il2CppAssetBundleManager()
     {
+        // icalls whose signature hasn't changed.
         GetAllLoadedAssetBundles_NativeDelegateField = IL2CPP.ResolveICall<GetAllLoadedAssetBundles_NativeDelegate>("UnityEngine.AssetBundle::GetAllLoadedAssetBundles_Native");
-        LoadFromFile_InternalDelegateField = IL2CPP.ResolveICall<LoadFromFile_InternalDelegate>("UnityEngine.AssetBundle::LoadFromFile_Internal(System.String,System.UInt32,System.UInt64)");
-        LoadFromFileAsync_InternalDelegateField = IL2CPP.ResolveICall<LoadFromFileAsync_InternalDelegate>("UnityEngine.AssetBundle::LoadFromFileAsync_Internal");
-        LoadFromMemory_InternalDelegateField = IL2CPP.ResolveICall<LoadFromMemory_InternalDelegate>("UnityEngine.AssetBundle::LoadFromMemory_Internal");
-        LoadFromMemoryAsync_InternalDelegateField = IL2CPP.ResolveICall<LoadFromMemoryAsync_InternalDelegate>("UnityEngine.AssetBundle::LoadFromMemoryAsync_Internal");
-        LoadFromStreamInternalDelegateField = IL2CPP.ResolveICall<LoadFromStreamInternalDelegate>("UnityEngine.AssetBundle::LoadFromStreamInternal");
-        LoadFromStreamAsyncInternalDelegateField = IL2CPP.ResolveICall<LoadFromStreamAsyncInternalDelegate>("UnityEngine.AssetBundle::LoadFromStreamAsyncInternal");
         UnloadAllAssetBundlesDelegateField = IL2CPP.ResolveICall<UnloadAllAssetBundlesDelegate>("UnityEngine.AssetBundle::UnloadAllAssetBundles");
+
+        if (UnityInformationHandler.EngineVersion.Major >= 6000) // Unity 6 icalls added the _Injected postfix
+        {
+            LoadFromFile_InternalDelegateField_Unity6 = IL2CPP.ResolveICall<LoadFromFile_InternalDelegate_Unity6>("UnityEngine.AssetBundle::LoadFromFile_Internal_Injected(System.String,System.UInt32,System.UInt64)");
+            LoadFromFileAsync_InternalDelegateField_Unity6 = IL2CPP.ResolveICall<LoadFromFileAsync_InternalDelegate_Unity6>("UnityEngine.AssetBundle::LoadFromFileAsync_Internal_Injected");
+            LoadFromMemory_InternalDelegateField_Unity6 = IL2CPP.ResolveICall<LoadFromMemory_InternalDelegate_Unity6>("UnityEngine.AssetBundle::LoadFromMemory_Internal_Injected");
+            LoadFromMemoryAsync_InternalDelegateField_Unity6 = IL2CPP.ResolveICall<LoadFromMemoryAsync_InternalDelegate_Unity6>("UnityEngine.AssetBundle::LoadFromMemoryAsync_Internal_Injected");
+            // The parameters of these functions below didn't change, but the signature DID change.
+            LoadFromStreamInternalDelegateField = IL2CPP.ResolveICall<LoadFromStreamInternalDelegate>("UnityEngine.AssetBundle::LoadFromStreamInternal_Injected");
+            LoadFromStreamAsyncInternalDelegateField = IL2CPP.ResolveICall<LoadFromStreamAsyncInternalDelegate>("UnityEngine.AssetBundle::LoadFromStreamAsyncInternal_Injected");   
+        }
+        else
+        {
+            LoadFromFile_InternalDelegateField = IL2CPP.ResolveICall<LoadFromFile_InternalDelegate>("UnityEngine.AssetBundle::LoadFromFile_Internal(System.String,System.UInt32,System.UInt64)");
+            LoadFromFileAsync_InternalDelegateField = IL2CPP.ResolveICall<LoadFromFileAsync_InternalDelegate>("UnityEngine.AssetBundle::LoadFromFileAsync_Internal");
+            LoadFromMemory_InternalDelegateField = IL2CPP.ResolveICall<LoadFromMemory_InternalDelegate>("UnityEngine.AssetBundle::LoadFromMemory_Internal");
+            LoadFromMemoryAsync_InternalDelegateField = IL2CPP.ResolveICall<LoadFromMemoryAsync_InternalDelegate>("UnityEngine.AssetBundle::LoadFromMemoryAsync_Internal");
+            LoadFromStreamInternalDelegateField = IL2CPP.ResolveICall<LoadFromStreamInternalDelegate>("UnityEngine.AssetBundle::LoadFromStreamInternal");
+            LoadFromStreamAsyncInternalDelegateField = IL2CPP.ResolveICall<LoadFromStreamAsyncInternalDelegate>("UnityEngine.AssetBundle::LoadFromStreamAsyncInternal");
+            UnloadAllAssetBundlesDelegateField = IL2CPP.ResolveICall<UnloadAllAssetBundlesDelegate>("UnityEngine.AssetBundle::UnloadAllAssetBundles");
+        }
     }
 
     public static Il2CppAssetBundle[] GetAllLoadedAssetBundles()
@@ -40,10 +67,31 @@ public class Il2CppAssetBundleManager
     {
         if (string.IsNullOrEmpty(path))
             throw new System.ArgumentException("The input asset bundle path cannot be null or empty.");
-        if (LoadFromFile_InternalDelegateField == null)
-            throw new System.NullReferenceException("The LoadFromFile_InternalDelegateField cannot be null.");
-        var intPtr = LoadFromFile_InternalDelegateField(IL2CPP.ManagedStringToIl2Cpp(path), crc, offset);
-        return ((intPtr != System.IntPtr.Zero) ? new Il2CppAssetBundle(intPtr) : null);
+        if (UnityInformationHandler.EngineVersion.Major >= 6000)
+        {
+            if (LoadFromFile_InternalDelegateField_Unity6 == null)
+                throw new System.NullReferenceException("The LoadFromFile_InternalDelegateField_Unity6 cannot be null.");
+            unsafe
+            {
+                fixed (char* charPtr = path)
+                {
+                    var span = new ManagedSpanWrapper
+                    {
+                        begin = charPtr,
+                        length = path.Length
+                    };
+                    var gcHandle = LoadFromFile_InternalDelegateField_Unity6(ref span, crc, offset);
+                    return ((gcHandle != System.IntPtr.Zero) ? new Il2CppAssetBundle(IL2CPP.il2cpp_gchandle_get_target(gcHandle)) : null);
+                }
+            }
+        }
+        else
+        {
+            if (LoadFromFile_InternalDelegateField == null)
+                throw new System.NullReferenceException("The LoadFromFile_InternalDelegateField cannot be null.");
+            var intPtr = LoadFromFile_InternalDelegateField(IL2CPP.ManagedStringToIl2Cpp(path), crc, offset);
+            return ((intPtr != System.IntPtr.Zero) ? new Il2CppAssetBundle(intPtr) : null);
+        }
     }
 
     public static Il2CppAssetBundleCreateRequest LoadFromFileAsync(string path) => LoadFromFileAsync(path, 0u, 0UL);
@@ -54,10 +102,31 @@ public class Il2CppAssetBundleManager
     {
         if (string.IsNullOrEmpty(path))
             throw new System.ArgumentException("The input asset bundle path cannot be null or empty.");
-        if (LoadFromFileAsync_InternalDelegateField == null)
-            throw new System.NullReferenceException("The LoadFromFileAsync_InternalDelegateField cannot be null.");
-        var intPtr = LoadFromFileAsync_InternalDelegateField(IL2CPP.ManagedStringToIl2Cpp(path), crc, offset);
-        return ((intPtr != System.IntPtr.Zero) ? new Il2CppAssetBundleCreateRequest(intPtr) : null);
+        if (UnityInformationHandler.EngineVersion.Major >= 6000)
+        {
+            if (LoadFromFileAsync_InternalDelegateField_Unity6 == null)
+                throw new System.NullReferenceException("The LoadFromFileAsync_InternalDelegateField_Unity6 cannot be null.");
+            unsafe
+            {
+                fixed (char* charPtr = path)
+                {
+                    var span = new ManagedSpanWrapper
+                    {
+                        begin = charPtr,
+                        length = path.Length
+                    };
+                    var intPtr = LoadFromFileAsync_InternalDelegateField_Unity6(ref span, crc, offset);
+                    return ((intPtr != System.IntPtr.Zero) ? new Il2CppAssetBundleCreateRequest(intPtr) : null);
+                }
+            }
+        }
+        else
+        {
+            if (LoadFromFileAsync_InternalDelegateField == null)
+                throw new System.NullReferenceException("The LoadFromFileAsync_InternalDelegateField cannot be null.");
+            var intPtr = LoadFromFileAsync_InternalDelegateField(IL2CPP.ManagedStringToIl2Cpp(path), crc, offset);
+            return ((intPtr != System.IntPtr.Zero) ? new Il2CppAssetBundleCreateRequest(intPtr) : null);
+        }
     }
 
     public static Il2CppAssetBundle LoadFromMemory(Il2CppStructArray<byte> binary) => LoadFromMemory(binary, 0u);
@@ -66,10 +135,29 @@ public class Il2CppAssetBundleManager
     {
         if (binary == null)
             throw new System.ArgumentException("The binary cannot be null or empty.");
-        if (LoadFromMemory_InternalDelegateField == null)
-            throw new System.NullReferenceException("The LoadFromMemory_InternalDelegateField cannot be null.");
-        var intPtr = LoadFromMemory_InternalDelegateField(IL2CPP.Il2CppObjectBaseToPtrNotNull(binary), crc);
-        return ((intPtr != System.IntPtr.Zero) ? new Il2CppAssetBundle(intPtr) : null);
+        if (UnityInformationHandler.EngineVersion.Major >= 6000)
+        {
+            if (LoadFromMemory_InternalDelegateField_Unity6 == null)
+                throw new System.NullReferenceException("The LoadFromMemory_InternalDelegateField_Unity6 cannot be null.");
+            unsafe
+            {
+                var arrayPtr = IL2CPP.Il2CppObjectBaseToPtr(binary);
+                var span = new ManagedSpanWrapper
+                {
+                    begin = (void*)(arrayPtr + 0x20), // Skip the IL2CPP object header.
+                    length = binary.Length
+                };
+                var gcHandle = LoadFromMemory_InternalDelegateField_Unity6(ref span, crc);
+                return ((gcHandle != System.IntPtr.Zero) ? new Il2CppAssetBundle(IL2CPP.il2cpp_gchandle_get_target(gcHandle)) : null);
+            }
+        }
+        else
+        {
+            if (LoadFromMemory_InternalDelegateField == null)
+                throw new System.NullReferenceException("The LoadFromMemory_InternalDelegateField cannot be null.");
+            var intPtr = LoadFromMemory_InternalDelegateField(IL2CPP.Il2CppObjectBaseToPtrNotNull(binary), crc);
+            return ((intPtr != System.IntPtr.Zero) ? new Il2CppAssetBundle(intPtr) : null);
+        }
     }
 
     public static Il2CppAssetBundleCreateRequest LoadFromMemoryAsync(Il2CppStructArray<byte> binary) => LoadFromMemoryAsync(binary, 0u);
@@ -78,10 +166,29 @@ public class Il2CppAssetBundleManager
     {
         if (binary == null)
             throw new System.ArgumentException("The binary cannot be null or empty.");
-        if (LoadFromMemoryAsync_InternalDelegateField == null)
-            throw new System.NullReferenceException("The LoadFromMemoryAsync_InternalDelegateField cannot be null.");
-        var intPtr = LoadFromMemoryAsync_InternalDelegateField(IL2CPP.Il2CppObjectBaseToPtrNotNull(binary), crc);
-        return ((intPtr != System.IntPtr.Zero) ? new Il2CppAssetBundleCreateRequest(intPtr) : null);
+        if (UnityInformationHandler.EngineVersion.Major >= 6000)
+        {
+            if (LoadFromMemoryAsync_InternalDelegateField_Unity6 == null)
+                throw new System.NullReferenceException("The LoadFromMemoryAsync_InternalDelegateField_Unity6 cannot be null.");
+            unsafe
+            {
+                var arrayPtr = IL2CPP.Il2CppObjectBaseToPtr(binary);
+                var span = new ManagedSpanWrapper
+                {
+                    begin = (void*)(arrayPtr + 0x20), // Skip the IL2CPP object header.
+                    length = binary.Length
+                };
+                var intPtr = LoadFromMemoryAsync_InternalDelegateField_Unity6(ref span, crc);
+                return ((intPtr != System.IntPtr.Zero) ? new Il2CppAssetBundleCreateRequest(intPtr) : null);
+            }
+        }
+        else
+        {
+            if (LoadFromMemoryAsync_InternalDelegateField == null)
+                throw new System.NullReferenceException("The LoadFromMemoryAsync_InternalDelegateField cannot be null.");
+            var intPtr = LoadFromMemoryAsync_InternalDelegateField(IL2CPP.Il2CppObjectBaseToPtrNotNull(binary), crc);
+            return ((intPtr != System.IntPtr.Zero) ? new Il2CppAssetBundleCreateRequest(intPtr) : null);
+        }
     }
 
     public static Il2CppAssetBundle LoadFromStream(Stream stream) => LoadFromStream(stream, 0u, 0u);
@@ -94,8 +201,8 @@ public class Il2CppAssetBundleManager
             throw new System.ArgumentException("The stream cannot be null or empty.");
         if (LoadFromStreamInternalDelegateField == null)
             throw new System.NullReferenceException("The LoadFromStreamInternalDelegateField cannot be null.");
-        var intPtr = LoadFromStreamInternalDelegateField(IL2CPP.Il2CppObjectBaseToPtrNotNull(stream), crc, managedReadBufferSize);
-        return ((intPtr != System.IntPtr.Zero) ? new Il2CppAssetBundle(intPtr) : null);
+        var gcHandle = LoadFromStreamInternalDelegateField(IL2CPP.Il2CppObjectBaseToPtrNotNull(stream), crc, managedReadBufferSize);
+        return ((gcHandle != System.IntPtr.Zero) ? new Il2CppAssetBundle(IL2CPP.il2cpp_gchandle_get_target(gcHandle)) : null);
     }
 
     public static Il2CppAssetBundleCreateRequest LoadFromStreamAsync(Stream stream) => LoadFromStreamAsync(stream, 0u, 0u);
@@ -135,4 +242,18 @@ public class Il2CppAssetBundleManager
     private static readonly LoadFromStreamAsyncInternalDelegate LoadFromStreamAsyncInternalDelegateField;
     private delegate System.IntPtr UnloadAllAssetBundlesDelegate(bool unloadAllObjects);
     private static readonly UnloadAllAssetBundlesDelegate UnloadAllAssetBundlesDelegateField;
+
+    // Unity 6 new signatures.
+    // GetAllLoadedAssetBundles doesn't change.
+    private delegate System.IntPtr LoadFromFile_InternalDelegate_Unity6(ref ManagedSpanWrapper path, uint crc, ulong offset);
+    private static readonly LoadFromFile_InternalDelegate_Unity6 LoadFromFile_InternalDelegateField_Unity6;
+    private delegate System.IntPtr LoadFromFileAsync_InternalDelegate_Unity6(ref ManagedSpanWrapper path, uint crc, ulong offset);
+    private static readonly LoadFromFileAsync_InternalDelegate_Unity6 LoadFromFileAsync_InternalDelegateField_Unity6;
+    private delegate System.IntPtr LoadFromMemory_InternalDelegate_Unity6(ref ManagedSpanWrapper binary, uint crc);
+    private static readonly LoadFromMemory_InternalDelegate_Unity6 LoadFromMemory_InternalDelegateField_Unity6;
+    private delegate System.IntPtr LoadFromMemoryAsync_InternalDelegate_Unity6(ref ManagedSpanWrapper binary, uint crc);
+    private static readonly LoadFromMemoryAsync_InternalDelegate_Unity6 LoadFromMemoryAsync_InternalDelegateField_Unity6;
+    // LoadFromStream doesn't change.
+    // LoadFromStreamAsync doesn't change.
+    // UnloadAllAssetBundles doesn't change.
 }

--- a/UnityUtilities/UnityEngine.Il2CppAssetBundleManager/UnityEngine.Il2CppAssetBundleManager.csproj
+++ b/UnityUtilities/UnityEngine.Il2CppAssetBundleManager/UnityEngine.Il2CppAssetBundleManager.csproj
@@ -8,6 +8,7 @@
 
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)\MelonLoader\MelonLoader.csproj" Private="false" />
+        <PackageReference Include="AssetRipper.Primitives" Version="3.2.0" />
         <PackageReference Include="Il2CppInterop.Runtime" Version="$(Il2CppInteropVersion)" Private="false">
           <ExcludeAssets>runtime</ExcludeAssets>
         </PackageReference>


### PR DESCRIPTION
This fixes Il2CppAssetBundleManager and Il2CppAssetBundle not working in Unity 6 by doing the following:
- Fixing the signatures for the delegates, since now Unity 6 icalls have the **_Injected** postfix.
- Adding extra delegates for functions where the *parameters* changed in Unity 6.
- Handling functions where the resulting pointer is actually a **GCHandle** and not the object itself (due to the new Unity 6 marshalling API).
- When loading an asset bundle, getting the *actual* bundle pointer by getting the objects' cachedPtr.
- Added *AssetRipper.Primitives* as a reference to *Il2CppAssetBundleManager.csproj* so we detect the Unity version that's being used, and then apply the changes depending of the version.

Tested in **Unity** Versions:
- **2022.3.62f2**
- **6000.3.10f1**