### PR TITLE
Fix/macos interpose section

### DIFF
--- a/MelonLoader.Bootstrap/MelonLoader.Bootstrap.csproj
+++ b/MelonLoader.Bootstrap/MelonLoader.Bootstrap.csproj
@@ -23,12 +23,28 @@
         <LinkStandardCPlusPlusLibrary>true</LinkStandardCPlusPlusLibrary>
     </PropertyGroup>
 
+    <PropertyGroup Condition="'$(RuntimeIdentifier)' == 'osx-x64'">
+        <OSXEntryArch>x86_64</OSXEntryArch>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(RuntimeIdentifier)' == 'osx-arm64'">
+        <OSXEntryArch>arm64</OSXEntryArch>
+    </PropertyGroup>
+
     <Target Condition="'$(RuntimeIdentifier.StartsWith(`osx-`))' == 'true'" Name="BuildOSXEntry" BeforeTargets="Build">
-        <Exec Command="g++ -c -O2 -fPIC OSXEntry/osxentry.cpp -o $(OSXEntryPath)" />
+        <!-- -arch is required because g++ on Apple Silicon defaults to arm64, producing
+             an object file that ld64 silently ignores when linking an x86_64 dylib. -->
+        <Exec Command="g++ -arch $(OSXEntryArch) -c -O2 -fPIC OSXEntry/osxentry.cpp -o $(OSXEntryPath)" />
     </Target>
 
     <ItemGroup Condition="'$(RuntimeIdentifier.StartsWith(`win-`))' == 'true'">
         <LinkerArg Include="/DEF:Exports.def" />
+    </ItemGroup>
+
+    <!-- Force ld64 to keep _SetRlimitHook and, by extension, the __DATA,__interpose struct
+         that references it. Without this, dead-stripping removes the interpose entry that
+         triggers MelonLoader on macOS, because nothing in the managed code references it. -->
+    <ItemGroup Condition="'$(RuntimeIdentifier.StartsWith(`osx-`))' == 'true'">
+        <LinkerArg Include="-Wl,-u,_SetRlimitHook" />
     </ItemGroup>
 
     <PropertyGroup Condition="'$(Configuration)' != 'Debug'">

--- a/MelonLoader.Bootstrap/MelonLoader.Bootstrap.csproj
+++ b/MelonLoader.Bootstrap/MelonLoader.Bootstrap.csproj
@@ -47,6 +47,16 @@
         <LinkerArg Include="-Wl,-u,_SetRlimitHook" />
     </ItemGroup>
 
+    <!-- Ship the launch wrapper alongside the dylib so end users have a ready-made
+         Steam launch option that survives macOS LaunchServices stripping DYLD_*.
+         Source file is committed with +x in the index; CopyToOutputDirectory and
+         Publish preserve Unix permissions on macOS so no chmod is needed. -->
+    <ItemGroup Condition="'$(RuntimeIdentifier.StartsWith(`osx-`))' == 'true'">
+        <None Include="OSXEntry/melonloader-launch.sh"
+              CopyToOutputDirectory="PreserveNewest"
+              Link="melonloader-launch.sh" />
+    </ItemGroup>
+
     <PropertyGroup Condition="'$(Configuration)' != 'Debug'">
         <DebugSymbols>false</DebugSymbols>
         <DebugType>none</DebugType>

--- a/MelonLoader.Bootstrap/OSXEntry/melonloader-launch.sh
+++ b/MelonLoader.Bootstrap/OSXEntry/melonloader-launch.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+#
+# MelonLoader launch wrapper for macOS Steam games.
+#
+# Why this exists:
+#   When Steam on macOS launches a .app bundle, macOS LaunchServices creates
+#   a fresh process that does not inherit the DYLD_INSERT_LIBRARIES env var
+#   needed to inject MelonLoader. This wrapper sidesteps LaunchServices by
+#   execing the inner binary directly with the env vars set, so the game
+#   process inherits DYLD_INSERT_LIBRARIES the normal Unix way.
+#
+# Installation:
+#   Install MelonLoader into the game folder (either via MelonLoader.Installer
+#   or by extracting the macOS build zip). The resulting layout should be:
+#
+#     <steamapps>/common/<GameName>/
+#     ├── <GameName>.app/
+#     ├── MelonLoader.Bootstrap.dylib
+#     ├── melonloader-launch.sh
+#     └── MelonLoader/
+#
+#   Then set the game's Steam Launch Options to:
+#     "/full/absolute/path/to/melonloader-launch.sh" %command%
+#
+#   Note: the path must be absolute. Steam on macOS does not resolve
+#   relative paths in Launch Options relative to the game's common folder,
+#   so "./melonloader-launch.sh" will fail with a generic launch error.
+#
+# The script auto-detects the .app bundle sitting next to it and resolves
+# the game binary via Info.plist's CFBundleExecutable, so no per-game edits
+# are required.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BOOTSTRAP_PATH="$SCRIPT_DIR/MelonLoader.Bootstrap.dylib"
+
+# Find the one .app bundle next to this script.
+shopt -s nullglob
+APPS=("$SCRIPT_DIR"/*.app)
+shopt -u nullglob
+if [ ${#APPS[@]} -ne 1 ]; then
+    echo "melonloader-launch: expected exactly one .app bundle in $SCRIPT_DIR, found ${#APPS[@]}; launching without MelonLoader" >&2
+    exec "$@"
+fi
+APP="${APPS[0]}"
+
+# Resolve the game binary via CFBundleExecutable.
+BINARY_NAME=$(/usr/libexec/PlistBuddy -c "Print CFBundleExecutable" "$APP/Contents/Info.plist" 2>/dev/null || true)
+BINARY="$APP/Contents/MacOS/$BINARY_NAME"
+
+if [ -z "$BINARY_NAME" ] || [ ! -x "$BINARY" ] || [ ! -f "$BOOTSTRAP_PATH" ]; then
+    echo "melonloader-launch: missing binary ($BINARY) or bootstrap dylib ($BOOTSTRAP_PATH); launching without MelonLoader" >&2
+    exec "$@"
+fi
+
+# If Steam handed us the .app bundle path (absolute or relative), redirect
+# to the inner binary. Compare via realpath-style resolution so "./Foo.app"
+# and "/abs/path/to/Foo.app" both match.
+if [ -d "${1:-}" ] && [ "${1%.app}" != "$1" ]; then
+    FIRST_ARG_ABS="$(cd "$1" && pwd)"
+    if [ "$FIRST_ARG_ABS" = "$APP" ]; then
+        shift
+        set -- "$BINARY" "$@"
+    fi
+fi
+
+# Both the dylib and the managed MelonLoader/ folder live in SCRIPT_DIR
+# alongside the .app; point DYLD_LIBRARY_PATH there so the managed side's
+# bare-filename NativeLibrary.Load("MelonLoader.Bootstrap.dylib") resolves.
+export DYLD_LIBRARY_PATH="$SCRIPT_DIR"
+
+# Prepend the bootstrap to Steam's own injected dylibs (overlay, steamloader)
+# rather than replacing them, so the Steam overlay keeps working.
+if [ -n "$STEAM_DYLD_INSERT_LIBRARIES" ]; then
+    export DYLD_INSERT_LIBRARIES="$BOOTSTRAP_PATH:$STEAM_DYLD_INSERT_LIBRARIES"
+else
+    export DYLD_INSERT_LIBRARIES="$BOOTSTRAP_PATH"
+fi
+
+exec "$@"

--- a/MelonLoader.Bootstrap/OSXEntry/osxentry.cpp
+++ b/MelonLoader.Bootstrap/OSXEntry/osxentry.cpp
@@ -3,6 +3,7 @@
 extern "C"
 {
     void Init();
+    int SetRlimitHook(int resource, rlimit* rlp);
 }
 
 #define DYLD_INTERPOSE(_replacement,_replacee) \


### PR DESCRIPTION
# Fix macOS bootstrap init and ship a Steam launch wrapper

Fixes the macOS support from #900 so `MelonLoader.Bootstrap.dylib` actually initializes on a fresh install, and ships a launch wrapper so end users can use it with Steam on macOS.

## The bug

`Init()` never gets called on macOS. The dylib loads fine and `_Init` is exported, but `otool -l` shows **no `__interpose` section** - the sole trigger mechanism is missing from the final binary.

Three independent issues combined to cause this:

1. **`BuildOSXEntry` builds `osxentry.o` for the wrong arch.** g++ is invoked without `-arch`, so on Apple Silicon hosts (including `macos-latest` on GitHub Actions) it produces an arm64 object. `ld64` silently ignores it when linking the x86_64 dylib. `SetRlimitHook` never enters the link graph.

2. **`SetRlimitHook` gets C++ name-mangled.** Only `Init()` was inside `extern "C"` in `osxentry.cpp`, so `SetRlimitHook` was emitted as `_Z13SetRlimitHookiP6rlimit`. The interpose struct still references it correctly at compile time, but no clean symbol exists for any linker-level "keep" directive.

3. **`ld64 -dead_strip` drops the interpose struct** because nothing in the managed code references `SetRlimitHook`. `__attribute__((used))` only protects against compiler-level stripping, not linker-level.

## The fix

- **`.csproj`**: pass `-arch $(OSXEntryArch)` to g++, driven by a new property that maps RID to arch
- **`.csproj`**: add `<LinkerArg Include="-Wl,-u,_SetRlimitHook" />` for `osx-*` RIDs to force `ld64` to keep the symbol and its referenced interpose struct
- **`osxentry.cpp`**: declare `SetRlimitHook` inside `extern "C"` so the `-u` arg can find it

## The wrapper (second commit)

Fixing the dylib alone isn't enough for Steam users on macOS. Steam launches `.app` bundles via LaunchServices, which creates a fresh process that **doesn't inherit `DYLD_INSERT_LIBRARIES`**. This is macOS-specific - Linux Steam uses plain `exec` which inherits env normally, which is why no wrapper is needed there.

The wrapper:
- Auto-detects the `.app` next to itself and resolves the binary via `CFBundleExecutable` (works for any game, no edits)
- Sets `DYLD_LIBRARY_PATH` + `DYLD_INSERT_LIBRARIES` in its own shell
- Merges with Steam's own `STEAM_DYLD_INSERT_LIBRARIES` so the overlay keeps working
- `exec`s the inner binary directly, bypassing LaunchServices so env vars survive into the game
- Falls through to `exec "$@"` if anything's missing, launching without MelonLoader rather than breaking the game

Shipped in `Output/Release/osx-x64/` next to the dylib and `MelonLoader/` folder.

**End-user install:**
1. Install with Melon Loader Installer after [PR121](https://github.com/LavaGang/MelonLoader.Installer/pull/121) is merged
2. Steam Launch Options: `"/full/path/to/melonloader-launch.sh" %command%`

or

1. `MelonLoader.Bootstrap.dylib` → `<Game>.app/Contents/MacOS/`
2. `MelonLoader/` and `melonloader-launch.sh` → next to `<Game>.app`
3. Steam Launch Options: `"/full/path/to/melonloader-launch.sh" %command%`

## Verification

Built on Apple Silicon M4 with .NET 10 SDK. `otool -l` on the resulting dylib now shows the `__interpose` section (size `0x10`, one entry mapping `SetRlimitHook` → `setrlimit`).

End-to-end tested on Chef RPG (Unity 2019.4, Mono, Rosetta 2) both via direct Terminal launch and via Steam with the wrapper. MelonLoader initializes cleanly, Mono hooks apply, log output appears, no workaround shim required.

Should close #1092 / #1087 
