### PR TITLE
Fallback to existing Il2Cpp assemblies when generation fails

### DIFF
--- a/Dependencies/Il2CppAssemblyGenerator/Core.cs
+++ b/Dependencies/Il2CppAssemblyGenerator/Core.cs
@@ -109,14 +109,14 @@ namespace MelonLoader.Il2CppAssemblyGenerator
             if (!cpp2il.Execute())
             {
                 cpp2il.Cleanup();
-                return 1;
+                return TryContinueWithExistingAssemblies();
             }
 
             if (!il2cppinterop.Execute())
             {
                 cpp2il.Cleanup();
                 il2cppinterop.Cleanup();
-                return 1;
+                return TryContinueWithExistingAssemblies();
             }
 
             OldFiles_Cleanup();
@@ -130,6 +130,20 @@ namespace MelonLoader.Il2CppAssemblyGenerator
             Config.Values.GameAssemblyHash = CurrentGameAssemblyHash;
             Config.Save();
 
+            return 0;
+        }
+
+        private static int TryContinueWithExistingAssemblies()
+        {
+            if (LoaderConfig.Current.UnityEngine.ForceRegeneration)
+                return 1;
+
+            if (!Directory.Exists(MelonEnvironment.Il2CppAssembliesDirectory)
+                || Directory.GetFiles(MelonEnvironment.Il2CppAssembliesDirectory, "*.dll").Length <= 0)
+                return 1;
+
+            Logger.Warning("Assembly Generation failed, but existing Il2Cpp assemblies were found.");
+            Logger.Warning("Continuing with the existing assemblies. Mods may be incompatible until generation succeeds.");
             return 0;
         }
 


### PR DESCRIPTION
## Summary
- allow Il2CppAssemblyGenerator to continue with existing generated Il2Cpp assemblies when Cpp2IL or Il2CppInterop generation fails
- keep forced regeneration strict: `ForceRegeneration` still fails instead of falling back
- warn that the existing assemblies may be incompatible until generation succeeds

## Why
Some games can fail regeneration after an update, while previously generated assemblies are still present and good enough for MelonLoader to start. Currently generation failure aborts startup even when those assemblies are available.

## Testing
- `dotnet build MelonLoader.sln -c Release`
- Reproduced with Toram Online where Cpp2IL fails to locate registration structs, but existing `MelonLoader/Il2CppAssemblies` allows startup when generation is skipped.