### PR TITLE
Bandaid fix for Linux native games

### DIFF
--- a/MelonLoader.Bootstrap/Exports.cs
+++ b/MelonLoader.Bootstrap/Exports.cs
@@ -52,17 +52,23 @@ internal static class Exports
     // mess up.
     private static bool IsLikelyUnityPlayer()
     {
+        string? ProcessPath = Process.GetCurrentProcess().MainModule?.FileName;
+        string? ProcessDirectory = Path.GetDirectoryName(ProcessPath);
+        
+        if (ProcessPath is null || ProcessDirectory is null)
+            return false;
+
 #if OSX
-        string? parentProcessDirectory = Path.GetDirectoryName(Core.GameDir);
+        string? parentProcessDirectory = Path.GetDirectoryName(ProcessDirectory);
         if (parentProcessDirectory is null)
             return false;
         if (!Directory.Exists(Path.Combine(parentProcessDirectory, "Resources", "Data")))
             return false;
 #else
-        if (!Directory.Exists(Path.Combine(Core.GameDir, "Data")))
+        if (!Directory.Exists(Path.Combine(ProcessDirectory, "Data")))
         {
-            string fileName = Path.GetFileNameWithoutExtension(Core.ProcessPath);
-            string dataDirectory = Path.Combine(Core.GameDir, $"{fileName}_Data");
+            string fileName = Path.GetFileNameWithoutExtension(ProcessPath);
+            string dataDirectory = Path.Combine(ProcessDirectory, $"{fileName}_Data");
             if (!Directory.Exists(dataDirectory))
                 return false;
         }


### PR DESCRIPTION
be4916a changed IsLikelyUnityPlayer() to use Core.GameDir, which isn't initialized because it's only initialized in HookPlayerMain() AFTER the current executable is confirmed to be UnityPlayer. 

This commit reverts be4916a's changes to IsLikelyUnityPlayer() and pulls 0.7.2's Exports.ProcessPath & Exports.ProcessDirectory definitions into IsLikelyUnityPlayer() as local variables. 

It's kinda ugly, but it makes MelonLoader work on my system :)

(hopefully I made the PR correctly this time lol. I don't use git or github often. I think usually people make a local branch first, but I think the way I did it *should* work)