### PR TITLE
Improve RemoteAPI outage handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@
 
 ### v0.8.0
 
-1. 
+1. Improved RemoteAPI outage handling to report one warning instead of an error per host and retain cached Il2Cpp generation settings
 
 ---
 

--- a/Dependencies/Il2CppAssemblyGenerator/Packages/Cpp2IL.cs
+++ b/Dependencies/Il2CppAssemblyGenerator/Packages/Cpp2IL.cs
@@ -19,7 +19,9 @@ namespace MelonLoader.Il2CppAssemblyGenerator.Packages
             Version = LoaderConfig.Current.UnityEngine.ForceIl2CppDumperVersion;
 #if !DEBUG
             if (string.IsNullOrEmpty(Version) || Version.Equals("0.0.0.0"))
-                Version = RemoteAPI.Info.ForceDumperVersion;
+                Version = RemoteAPI.GetRemoteOrCachedValue(
+                    RemoteAPI.Info.ForceDumperVersion,
+                    Config.Values.DumperVersion);
 #endif
             if (string.IsNullOrEmpty(Version) || Version.Equals("0.0.0.0"))
                 Version = $"2022.1.0-pre-release.21";

--- a/Dependencies/Il2CppAssemblyGenerator/Packages/Cpp2IL_NetFramework.cs
+++ b/Dependencies/Il2CppAssemblyGenerator/Packages/Cpp2IL_NetFramework.cs
@@ -13,7 +13,9 @@ namespace MelonLoader.Il2CppAssemblyGenerator.Packages
             Version = LoaderConfig.Current.UnityEngine.ForceIl2CppDumperVersion;
 #if !DEBUG
             if (string.IsNullOrEmpty(Version) || Version.Equals("0.0.0.0"))
-                Version = RemoteAPI.Info.ForceDumperVersion;
+                Version = RemoteAPI.GetRemoteOrCachedValue(
+                    RemoteAPI.Info.ForceDumperVersion,
+                    Config.Values.DumperVersion);
 #endif
             if (string.IsNullOrEmpty(Version) || Version.Equals("0.0.0.0"))
                 Version = $"2022.1.0-pre-release.15";

--- a/Dependencies/Il2CppAssemblyGenerator/Packages/DeobfuscationRegex.cs
+++ b/Dependencies/Il2CppAssemblyGenerator/Packages/DeobfuscationRegex.cs
@@ -8,7 +8,9 @@
         {
             Regex = LoaderConfig.Current.UnityEngine.ForceGeneratorRegex;
             if (string.IsNullOrEmpty(Regex))
-                Regex = RemoteAPI.Info.ObfuscationRegex;
+                Regex = RemoteAPI.GetRemoteOrCachedValue(
+                    RemoteAPI.Info.ObfuscationRegex,
+                    Config.Values.DeobfuscationRegex);
         }
 
         internal void Setup()

--- a/Dependencies/Il2CppAssemblyGenerator/RemoteAPI.cs
+++ b/Dependencies/Il2CppAssemblyGenerator/RemoteAPI.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Net.Http;
+﻿using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
@@ -17,96 +15,120 @@ namespace MelonLoader.Il2CppAssemblyGenerator
             internal string MappingURL = null;
             internal string MappingFileSHA512 = null;
         }
+
         internal static InfoStruct Info = new InfoStruct();
+        internal static RemoteAPIContactResult? LastContactResult { get; private set; }
 
-        private class HostInfo
-        {
-            internal string URL = null;
-            internal LemonFunc<string, InfoStruct> Func = null;
-            internal HostInfo(string url, LemonFunc<string, InfoStruct> func)
-            {
-                URL = url;
-                Func = func;
-            }
-        }
-        private static List<HostInfo> HostList = null;
-
-        static RemoteAPI()
-        {
-            string gamename = Regex.Replace(InternalUtils.UnityInformationHandler.GameName, "[^a-zA-Z0-9_.]+", "-", RegexOptions.Compiled).ToLowerInvariant();
-
-            HostList = new List<HostInfo> {
-                new HostInfo($"{DefaultHostInfo.Melon.API_URL}{gamename}", DefaultHostInfo.Melon.Contact),
-                new HostInfo($"{DefaultHostInfo.Melon.API_URL_1}{gamename}", DefaultHostInfo.Melon.Contact),
-                new HostInfo($"{DefaultHostInfo.Melon.API_URL_2}{gamename}", DefaultHostInfo.Melon.Contact),
-                new HostInfo($"{DefaultHostInfo.Melon.API_URL_SAMBOY}{gamename}", DefaultHostInfo.Melon.Contact),
-                new HostInfo($"{DefaultHostInfo.Melon.API_URL_DUBYADUDE}{gamename}", DefaultHostInfo.Melon.Contact),
-            };
-        }
-
-        internal static void Contact()
+        internal static RemoteAPIContactResult Contact()
         {
             Core.Logger.Msg("Contacting RemoteAPI...");
 
-            ContactHosts();
+            Info = new InfoStruct();
+            RemoteAPIContactOutcome outcome = RemoteAPIClient.ContactHosts(
+                Core.webClient,
+                CreateHostList(),
+                MelonDebug.Msg);
+            LastContactResult = outcome.Result;
 
+            switch (outcome.Result)
+            {
+                case RemoteAPIContactResult.Success:
+                    Info = outcome.Info;
+                    NormalizeInfo();
+                    LogInfo();
+                    break;
+
+                case RemoteAPIContactResult.NotFound:
+                    Core.Logger.Msg($"Game Not Found on RemoteAPI Host ({outcome.HostURL})");
+                    LogInfo();
+                    break;
+
+                case RemoteAPIContactResult.Unavailable:
+                    Core.Logger.Warning(
+                        $"RemoteAPI is unavailable after trying {outcome.Failures.Count} hosts "
+                        + $"({BuildFailureSummary(outcome.Failures)}). "
+                        + "Continuing with locally cached generation settings when available.");
+                    break;
+            }
+
+            return outcome.Result;
+        }
+
+        internal static string GetRemoteOrCachedValue(string remoteValue, string cachedValue)
+            => LastContactResult == RemoteAPIContactResult.Unavailable
+                && !string.IsNullOrEmpty(cachedValue)
+                    ? cachedValue
+                    : remoteValue;
+
+        private static List<RemoteAPIHost> CreateHostList()
+        {
+            string gameName = Regex.Replace(
+                InternalUtils.UnityInformationHandler.GameName,
+                "[^a-zA-Z0-9_.]+",
+                "-",
+                RegexOptions.Compiled).ToLowerInvariant();
+
+            return new List<RemoteAPIHost> {
+                new RemoteAPIHost($"{DefaultHostInfo.Melon.API_URL}{gameName}", DefaultHostInfo.Melon.Contact),
+                new RemoteAPIHost($"{DefaultHostInfo.Melon.API_URL_1}{gameName}", DefaultHostInfo.Melon.Contact),
+                new RemoteAPIHost($"{DefaultHostInfo.Melon.API_URL_2}{gameName}", DefaultHostInfo.Melon.Contact),
+                new RemoteAPIHost($"{DefaultHostInfo.Melon.API_URL_SAMBOY}{gameName}", DefaultHostInfo.Melon.Contact),
+                new RemoteAPIHost($"{DefaultHostInfo.Melon.API_URL_DUBYADUDE}{gameName}", DefaultHostInfo.Melon.Contact),
+            };
+        }
+
+        private static void NormalizeInfo()
+        {
+            if (string.IsNullOrEmpty(Info.ForceDumperVersion))
+                return;
+
+            if (!SemVersion.TryParse(Info.ForceDumperVersion, out SemVersion version))
+            {
+                MelonDebug.Msg($"RemoteAPI returned an invalid Cpp2IL version '{Info.ForceDumperVersion}'. Ignoring it.");
+                Info.ForceDumperVersion = null;
+                return;
+            }
+
+            if (version <= SemVersion.Parse("2022.0.2"))
+                Info.ForceDumperVersion = null;
+        }
+
+        private static void LogInfo()
+        {
             Core.Logger.Msg($"RemoteAPI.DumperVersion = {(string.IsNullOrEmpty(Info.ForceDumperVersion) ? "null" : Info.ForceDumperVersion)}");
             Core.Logger.Msg($"RemoteAPI.ObfuscationRegex = {(string.IsNullOrEmpty(Info.ObfuscationRegex) ? "null" : Info.ObfuscationRegex)}");
             Core.Logger.Msg($"RemoteAPI.MappingURL = {(string.IsNullOrEmpty(Info.MappingURL) ? "null" : Info.MappingURL)}");
             Core.Logger.Msg($"RemoteAPI.MappingFileSHA512 = {(string.IsNullOrEmpty(Info.MappingFileSHA512) ? "null" : Info.MappingFileSHA512)}");
         }
 
-        private static void ContactHosts()
+        private static string BuildFailureSummary(IReadOnlyList<RemoteAPIHostFailure> failures)
         {
-            if ((HostList == null) || (HostList.Count <= 0))
-                return;
-            foreach (HostInfo info in HostList)
+            if (failures.Count <= 0)
+                return "no hosts configured";
+
+            Dictionary<string, int> reasonCounts = new Dictionary<string, int>();
+            List<string> reasons = new List<string>();
+            foreach (RemoteAPIHostFailure failure in failures)
             {
-                if (string.IsNullOrEmpty(info.URL) || (info.Func == null))
-                    continue;
-
-                MelonDebug.Msg($"ContactURL = {info.URL}");
-
-                string Response = null;
-                try
+                if (reasonCounts.TryGetValue(failure.Reason, out int count))
                 {
-                    var result = Core.webClient.GetAsync(info.URL).Result;
-                    result.EnsureSuccessStatusCode();
-                    Response = result.Content.ReadAsStringAsync().Result;
-                }
-                catch (Exception ex)
-                {
-                    if (ex is not HttpRequestException {StatusCode: {}} hre)
-                    {
-                        Core.Logger.Error($"Exception while Contacting RemoteAPI Host ({info.URL}): {ex}");
-                        continue;
-                    }
-
-                    if (hre.StatusCode == System.Net.HttpStatusCode.NotFound)
-                    {
-                        Core.Logger.Msg($"Game Not Found on RemoteAPI Host ({info.URL})");
-                        break;
-                    }
-
-                    Core.Logger.Error($"WebException ({hre.StatusCode}) while Contacting RemoteAPI Host ({info.URL}): {ex}");
+                    reasonCounts[failure.Reason] = count + 1;
                     continue;
                 }
 
-                var isResponseNull = string.IsNullOrEmpty(Response);
-                MelonDebug.Msg($"Response = {(isResponseNull ? "null" : Response) }");
-                if (isResponseNull)
-                    break;
-
-                InfoStruct returnInfo = info.Func(Response);
-                if (returnInfo == null)
-                    continue;
-
-                if (returnInfo.ForceDumperVersion != null && SemVersion.Parse(returnInfo.ForceDumperVersion) <= SemVersion.Parse("2022.0.2"))
-                    returnInfo.ForceDumperVersion = null;
-
-                Info = returnInfo;
-                break;
+                reasonCounts.Add(failure.Reason, 1);
+                reasons.Add(failure.Reason);
             }
+
+            for (int i = 0; i < reasons.Count; i++)
+            {
+                string reason = reasons[i];
+                int count = reasonCounts[reason];
+                if (count > 1)
+                    reasons[i] = $"{reason} x{count}";
+            }
+
+            return string.Join(", ", reasons);
         }
 
         private class DefaultHostInfo

--- a/Dependencies/Il2CppAssemblyGenerator/RemoteAPIClient.cs
+++ b/Dependencies/Il2CppAssemblyGenerator/RemoteAPIClient.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+
+namespace MelonLoader.Il2CppAssemblyGenerator
+{
+    internal enum RemoteAPIContactResult
+    {
+        Success,
+        NotFound,
+        Unavailable,
+    }
+
+    internal sealed class RemoteAPIHost
+    {
+        internal string URL { get; }
+        internal Func<string, RemoteAPI.InfoStruct> ParseResponse { get; }
+
+        internal RemoteAPIHost(string url, Func<string, RemoteAPI.InfoStruct> parseResponse)
+        {
+            URL = url;
+            ParseResponse = parseResponse;
+        }
+    }
+
+    internal sealed class RemoteAPIHostFailure
+    {
+        internal string URL { get; }
+        internal string Reason { get; }
+
+        internal RemoteAPIHostFailure(string url, string reason)
+        {
+            URL = url;
+            Reason = reason;
+        }
+    }
+
+    internal sealed class RemoteAPIContactOutcome
+    {
+        internal RemoteAPIContactResult Result { get; }
+        internal RemoteAPI.InfoStruct Info { get; }
+        internal string HostURL { get; }
+        internal IReadOnlyList<RemoteAPIHostFailure> Failures { get; }
+
+        internal RemoteAPIContactOutcome(
+            RemoteAPIContactResult result,
+            RemoteAPI.InfoStruct info,
+            string hostURL,
+            IReadOnlyList<RemoteAPIHostFailure> failures)
+        {
+            Result = result;
+            Info = info;
+            HostURL = hostURL;
+            Failures = failures;
+        }
+    }
+
+    internal static class RemoteAPIClient
+    {
+        internal static RemoteAPIContactOutcome ContactHosts(
+            HttpClient client,
+            IReadOnlyList<RemoteAPIHost> hosts,
+            Action<string> debugLog = null)
+        {
+            if (client == null)
+                throw new ArgumentNullException(nameof(client));
+            if (hosts == null)
+                throw new ArgumentNullException(nameof(hosts));
+
+            List<RemoteAPIHostFailure> failures = new List<RemoteAPIHostFailure>();
+
+            foreach (RemoteAPIHost host in hosts)
+            {
+                if (host == null || string.IsNullOrEmpty(host.URL) || host.ParseResponse == null)
+                {
+                    AddFailure(failures, host?.URL, "invalid host configuration", null, debugLog);
+                    continue;
+                }
+
+                debugLog?.Invoke($"ContactURL = {host.URL}");
+
+                HttpResponseMessage response;
+                try
+                {
+                    response = client.GetAsync(host.URL).GetAwaiter().GetResult();
+                }
+                catch (Exception ex)
+                {
+                    AddFailure(failures, host.URL, ex.GetType().Name, ex, debugLog);
+                    continue;
+                }
+
+                using (response)
+                {
+                    if (response.StatusCode == HttpStatusCode.NotFound)
+                    {
+                        return new RemoteAPIContactOutcome(
+                            RemoteAPIContactResult.NotFound,
+                            null,
+                            host.URL,
+                            failures);
+                    }
+
+                    if (!response.IsSuccessStatusCode)
+                    {
+                        string reason = $"{(int)response.StatusCode} {response.ReasonPhrase}".TrimEnd();
+                        AddFailure(failures, host.URL, reason, null, debugLog);
+                        continue;
+                    }
+
+                    string responseBody;
+                    try
+                    {
+                        responseBody = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+                    }
+                    catch (Exception ex)
+                    {
+                        AddFailure(failures, host.URL, ex.GetType().Name, ex, debugLog);
+                        continue;
+                    }
+
+                    if (string.IsNullOrWhiteSpace(responseBody))
+                    {
+                        AddFailure(failures, host.URL, "empty response", null, debugLog);
+                        continue;
+                    }
+
+                    debugLog?.Invoke($"Response = {responseBody}");
+
+                    RemoteAPI.InfoStruct info;
+                    try
+                    {
+                        info = host.ParseResponse(responseBody);
+                    }
+                    catch (Exception ex)
+                    {
+                        AddFailure(failures, host.URL, $"invalid response ({ex.GetType().Name})", ex, debugLog);
+                        continue;
+                    }
+
+                    if (info == null)
+                    {
+                        AddFailure(failures, host.URL, "invalid response", null, debugLog);
+                        continue;
+                    }
+
+                    return new RemoteAPIContactOutcome(
+                        RemoteAPIContactResult.Success,
+                        info,
+                        host.URL,
+                        failures);
+                }
+            }
+
+            return new RemoteAPIContactOutcome(
+                RemoteAPIContactResult.Unavailable,
+                null,
+                null,
+                failures);
+        }
+
+        private static void AddFailure(
+            ICollection<RemoteAPIHostFailure> failures,
+            string url,
+            string reason,
+            Exception exception,
+            Action<string> debugLog)
+        {
+            string displayURL = string.IsNullOrEmpty(url) ? "unknown" : url;
+            failures.Add(new RemoteAPIHostFailure(displayURL, reason));
+
+            string details = exception == null ? reason : $"{reason}: {exception}";
+            debugLog?.Invoke($"RemoteAPI Host ({displayURL}) failed: {details}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Distinguish successful, authoritative not-found, and temporarily unavailable RemoteAPI results.
- Continue across transient HTTP, transport, empty-response, and parsing failures.
- Replace repeated per-host errors with one grouped warning while retaining detailed debug logging.
- Reuse cached Cpp2IL versions and deobfuscation settings only when every RemoteAPI host is unavailable.
- Cover both modern and legacy .NET Framework Cpp2IL packages.
- Safely ignore malformed Cpp2IL versions returned by the API.

## Testing

- Il2CppAssemblyGenerator Release x64 build: passed with 0 errors (existing NU1701 warnings only).
- Il2CppAssemblyGenerator Release x86 build: passed with 0 errors (existing NU1701 warnings only).
- Temporary six-case behavioral harness: passed; no test infrastructure is included in this change.
- Two real-game startup smoke tests using a 0.7.3-compatible build:
  - one grouped warning and zero errors
  - cached Cpp2IL version retained
  - no unnecessary assembly generation
  - mod loaded and game exited cleanly
- Full solution build could not complete because the local Visual Studio installation lacks the C++/NativeAOT linker workload.

Addresses #1183