### PR TITLE
Fix stale Cpp2IL output cleanup

### DIFF
--- a/Dependencies/Il2CppAssemblyGenerator/Packages/Cpp2IL.cs
+++ b/Dependencies/Il2CppAssemblyGenerator/Packages/Cpp2IL.cs
@@ -57,8 +57,6 @@ namespace MelonLoader.Il2CppAssemblyGenerator.Packages
                 || !Config.Values.DumperVersion.Equals(Version);
         }
 
-        internal override void Cleanup() { }
-
         internal override void Save()
             => Save(ref Config.Values.DumperVersion);
 


### PR DESCRIPTION
## Summary

- let `Cpp2IL` inherit the standard executable-package cleanup
- remove stale `cpp2il_out` assemblies before each generation and after completion
- ensure Il2CppInterop only consumes assemblies emitted for the current game build

## Root cause

`Cpp2IL.Cleanup()` was overridden with an empty implementation. Cpp2IL writes into an existing directory without removing assemblies that disappeared between game versions, and Il2CppInterop reads every DLL in that directory.

The inherited `ExecutablePackage.Cleanup()` is already scoped to `OutputFolder`, so it removes `cpp2il_out` without removing the downloaded Cpp2IL executable.

Closes #1192.

## Cross-project source trace

- Cpp2IL `2022.1.0-pre-release.21` [creates the output directory if needed and writes current assemblies](https://github.com/SamboyCoding/Cpp2IL/blob/12c8b4413900558a14e30adc4fc4d13d82383901/Cpp2IL.Core/OutputFormats/AsmResolverDummyDllOutputFormat.cs#L25-L52), but does not remove assemblies it no longer emits.
- In the reproduced mixed directory, stale `Cinemachine.dll` from `0.4.5f2` references `UnityEngine.Camera.GateFitMode`; the current `0.4.6f11` CoreModule no longer defines that enum, and a clean current Cpp2IL run does not emit `Cinemachine.dll`.
- MelonLoader's pinned Il2CppInterop version [resolves and immediately consumes each field type in Pass 11](https://github.com/BepInEx/Il2CppInterop/blob/f03c8f4ae507d47ea814f3d11d1ec6b0391c1576/Il2CppInterop.Generator/Passes/Pass11ComputeTypeSpecifics.cs#L42-L43), explaining the observed null failure on that cross-version graph.
- [BepInEx/Il2CppInterop#275](https://github.com/BepInEx/Il2CppInterop/pull/275) independently reports the same game, Unity version, stack, and exact `Cinemachine.LensSettings.GateFit -> UnityEngine.Camera.GateFitMode` reference. Its defensive downstream handling is complementary; this PR prevents MelonLoader from constructing the invalid mixed input set.

The full type-level evidence and controls are recorded in #1192.

## Verification

- `dotnet build MelonLoader.sln --no-restore -c Release -p:Platform=x64 -p:Version=0.7.3-stale-output-fix`
- `dotnet build MelonLoader.sln --no-restore -c Release -p:Platform=x86 -p:Version=0.7.3-stale-output-fix`
- reproduced the failure with official MelonLoader 0.7.3 by generating against Schedule I `0.4.5f2`, then updating the same disposable install to `0.4.6f11`
- confirmed the old run left 123 Cpp2IL DLLs while a clean current run emits 111; 12 removed game assemblies remained stale and caused `Pass11ComputeTypeSpecifics` to throw
- replaced only `Il2CppAssemblyGenerator.dll` with the source-built version while preserving all 123 stale inputs
- confirmed `0.4.6f11` regenerated successfully, removed `cpp2il_out`, retained none of the 12 old-only assemblies, and reached `Loading Mods` with zero generation errors
