### PR TITLE
Fix log rotation deleting the newest log instead of the oldest

### DIFF
--- a/MelonLoader.Bootstrap/Logging/MelonLogger.cs
+++ b/MelonLoader.Bootstrap/Logging/MelonLogger.cs
@@ -69,7 +69,7 @@ internal static class MelonLogger
         }
 
         var latestPath = Path.Combine(LoaderConfig.Current.Loader.BaseDirectory, "MelonLoader", "Latest.log");
-        var cachedPath = Path.Combine(logsDir, $"{DateTime.Now:%y-%M-%d_%H-%m-%s}.log");
+        var cachedPath = Path.Combine(logsDir, $"{DateTime.Now:yyyy-MM-dd_HH-mm-ss}.log");
 
         MelonDebug.Log("Opening stream to latest log");
         try

--- a/MelonLoader.Bootstrap/Logging/MelonLogger.cs
+++ b/MelonLoader.Bootstrap/Logging/MelonLogger.cs
@@ -49,12 +49,7 @@ internal static class MelonLogger
                 foreach (var file in logs)
                     queue.Add((file, File.GetLastWriteTime(file)));
 
-                queue.Sort((x, y) =>
-                {
-                    if (x.Item2 >= y.Item2)
-                        return 0;
-                    return 1;
-                });
+                queue.Sort((x, y) => x.Item2.CompareTo(y.Item2));
 
                 var toDelete = logs.Length - LoaderConfig.Current.Logs.MaxLogs + 1;
                 for (var i = 0; i < toDelete; i++)


### PR DESCRIPTION
`max_logs` cleanup deletes the newest log rather than the oldest.

The comparator in `MelonLogger.Init` returns `0` when `x` is newer than `y` and `1` when `x` is older, never a negative value, so for a pair where `x` is newer it claims both `x == y` and `y > x`. Not being a valid comparison function, it leaves the list in `Directory.GetFiles` order and `queue[0]` is deleted. On NTFS that order is by filename, and filenames use `%y-%M-%d_%H-%m-%s` with no zero padding, so `26-8-10_20-0-42` sorts ahead of `26-8-9_9-11-21`. The newest log goes first.

Seen on 0.7.2 with `max_logs = 10`: a log from that afternoon was deleted while nine from the previous day were kept. Replaying both comparators over those ten timestamps, the old one deletes the newest file, the new one deletes the oldest.

Second commit zero pads the filename to `yyyy-MM-dd_HH-mm-ss` so a listing sorted by name matches chronological order, and stays sortable past 2099. Nothing in the tree parses these names.

Managed compile verified. The native AOT link step was not run here, no C++ toolchain on this machine.
